### PR TITLE
fix(library): added wget to dependencies in installation

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -18,7 +18,8 @@ sudo --preserve-env apt install -y \
   ccache \
   ninja-build \
   checkinstall \
-  git
+  git \
+  wget
 
 function run_and_time {
   time "$@"


### PR DESCRIPTION
While creating a `Dockerfile` to evaluate [CI](https://github.com/substrait-io/substrait-cpp/issues/4#issuecomment-1364934929) approach, I found that it is better to include `wget` within the `scripts/setup-ubuntu.sh`. 