### PR TITLE
fix(naming):  Rename namespace 'substrait' to 'io::substrait'

### DIFF
--- a/include/substrait/common/Exceptions.h
+++ b/include/substrait/common/Exceptions.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <fmt/format.h>
 
-namespace substrait::common {
+namespace io::substrait::common {
 namespace error_code {
 
 //====================== User Error Codes ======================:
@@ -133,4 +133,4 @@ std::string errorMessage(fmt::string_view fmt, const Args&... args) {
       substrait::common::error_code::kInvalidArgument, \
       ##__VA_ARGS__)
 
-} // namespace substrait::common
+} // namespace io::substrait::common

--- a/include/substrait/function/Extension.h
+++ b/include/substrait/function/Extension.h
@@ -11,7 +11,7 @@
 #include "substrait/function/FunctionSignature.h"
 #include "substrait/type/Type.h"
 
-namespace substrait {
+namespace io::substrait {
 
 struct TypeVariant {
   std::string name;
@@ -80,4 +80,4 @@ class Extension {
 
 using ExtensionPtr = std::shared_ptr<const Extension>;
 
-} // namespace substrait
+} // namespace io::substrait

--- a/include/substrait/function/Function.h
+++ b/include/substrait/function/Function.h
@@ -5,7 +5,7 @@
 #include "substrait/type/Type.h"
 #include "substrait/function/FunctionSignature.h"
 
-namespace substrait {
+namespace io::substrait {
 
 struct FunctionArgument {
   [[nodiscard]] virtual bool isRequired() const = 0;
@@ -113,4 +113,4 @@ struct AggregateFunctionImplementation : public FunctionImplementation {
   bool tryMatch(const FunctionSignature& signature) override;
 };
 
-} // namespace substrait
+} // namespace io::substrait

--- a/include/substrait/function/FunctionLookup.h
+++ b/include/substrait/function/FunctionLookup.h
@@ -5,7 +5,7 @@
 #include "substrait/function/Extension.h"
 #include "substrait/function/FunctionSignature.h"
 
-namespace substrait {
+namespace io::substrait {
 
 class FunctionLookup {
  public:
@@ -58,4 +58,4 @@ class WindowFunctionLookup : public FunctionLookup {
   }
 };
 
-} // namespace substrait
+} // namespace io::substrait

--- a/include/substrait/function/FunctionSignature.h
+++ b/include/substrait/function/FunctionSignature.h
@@ -4,7 +4,7 @@
 
 #include "substrait/type/Type.h"
 
-namespace substrait {
+namespace io::substrait {
 
 struct FunctionSignature {
   std::string name;
@@ -12,4 +12,4 @@ struct FunctionSignature {
   TypePtr returnType;
 };
 
-} // namespace substrait
+} // namespace io::substrait

--- a/include/substrait/type/Type.h
+++ b/include/substrait/type/Type.h
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-namespace substrait {
+namespace io::substrait {
 
 enum class TypeKind : int8_t {
   kBool = 1,
@@ -653,4 +653,4 @@ std::shared_ptr<const Map> MAP(
 
 std::shared_ptr<const Struct> STRUCT(const std::vector<TypePtr>& children);
 
-} // namespace substrait
+} // namespace io::substrait

--- a/substrait/common/Exceptions.cpp
+++ b/substrait/common/Exceptions.cpp
@@ -3,7 +3,7 @@
 #include <fmt/format.h>
 #include "substrait/common/Exceptions.h"
 
-namespace substrait::common {
+namespace io::substrait::common {
 
 SubstraitException::SubstraitException(
     const std::string& exceptionCode,
@@ -21,4 +21,4 @@ SubstraitException::SubstraitException(
           __FILE__,
           std::to_string(__LINE__))) {}
 
-} // namespace substrait::common
+} // namespace io::substrait::common

--- a/substrait/function/Function.cpp
+++ b/substrait/function/Function.cpp
@@ -3,7 +3,7 @@
 #include <sstream>
 #include "substrait/function/Function.h"
 
-namespace substrait {
+namespace io::substrait {
 
 bool FunctionImplementation::tryMatch(const FunctionSignature& signature) {
   const auto& actualTypes = signature.arguments;
@@ -83,4 +83,4 @@ bool AggregateFunctionImplementation::tryMatch(const FunctionSignature& signatur
   return matched;
 }
 
-} // namespace substrait
+} // namespace io::substrait

--- a/substrait/function/FunctionLookup.cpp
+++ b/substrait/function/FunctionLookup.cpp
@@ -2,7 +2,7 @@
 
 #include "substrait/function/FunctionLookup.h"
 
-namespace substrait {
+namespace io::substrait {
 
 FunctionImplementationPtr FunctionLookup::lookupFunction(
     const FunctionSignature& signature) const {
@@ -19,4 +19,4 @@ FunctionImplementationPtr FunctionLookup::lookupFunction(
   return nullptr;
 }
 
-} // namespace substrait
+} // namespace io::substrait

--- a/substrait/function/tests/FunctionLookupTest.cpp
+++ b/substrait/function/tests/FunctionLookupTest.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 #include "substrait/function/FunctionLookup.h"
 
-using namespace substrait;
+using namespace io::substrait;
 
 class FunctionLookupTest : public ::testing::Test {
  protected:

--- a/substrait/type/Type.cpp
+++ b/substrait/type/Type.cpp
@@ -6,7 +6,7 @@
 #include "substrait/type/Type.h"
 #include "substrait/common/Exceptions.h"
 
-namespace substrait {
+namespace io::substrait {
 
 namespace {
 
@@ -504,4 +504,4 @@ bool StringLiteral::isMatch(
   }
 }
 
-} // namespace substrait
+} // namespace io::substrait

--- a/substrait/type/tests/TypeTest.cpp
+++ b/substrait/type/tests/TypeTest.cpp
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 #include "substrait/type/Type.h"
 
-using namespace substrait;
+using namespace io::substrait;
 
 class TypeTest : public ::testing::Test {
  protected:


### PR DESCRIPTION
Rename namespace from 'substrait' to 'io::substrait' to avoid conflicts with namespace defined in substrait proto files.