### PR TITLE
chore: Add the protobuf compiler package to the list of CI included packages.

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -22,4 +22,5 @@ sudo --preserve-env apt install -y \
   git \
   wget \
   libprotobuf-dev \
-  libprotobuf23
+  libprotobuf23 \
+  protobuf-compiler


### PR DESCRIPTION
Needed in advance of #11 so that the continuous integration will pass.
