### PR TITLE
Add ctest option --output-on-failure

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Build
         run: ninja -C build
       - name: Test
-        run: ctest --test-dir build
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
This should make it easier to determine the cause of CI failures.