### PR TITLE
Add lint to CI include checking for cmake-format, clang-format and license header

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 name: Ubuntu Build & Test
 
 on:
@@ -7,6 +8,22 @@ on:
     branches: [main]
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Ubuntu
+        run: ./scripts/setup-ubuntu.sh
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@v0.4.0
+      - name: Check CMake files
+        run: find . \( -name '*.cmake' -o -name 'CMakeLists.txt' \) -exec cmake-format $* {} +
+      - name: Clang-tidy
+        run: python3 scripts/run-clang-tidy.py "." "build" "third_party,scripts,docker,cmake_modules" "h,hpp,cc,cpp"
+      - run: mkdir build
   build:
     runs-on: ubuntu-latest
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,13 +1,22 @@
 header:
   license:
     spdx-id: Apache-2.0
-    copyright-owner: Apache Software Foundation
+    content: |
+      SPDX-License-Identifier: Apache-2.0
 
   paths-ignore:
-    - 'dist'
-    - 'licenses'
+    - '.github'
+    - '.gitignore'
+    - '.gitmodules'
+    - '.clang-format'
+    - '.clang-tidy'
+    - '.licenserc.yaml'
+    - 'third_party/fmt'
+    - 'third_party/googletest'
+    - 'third_party/substrait'
+    - 'third_party/yaml-cpp'
     - '**/*.md'
-    - 'LICENSE'
-    - 'NOTICE'
+    - '**/*.json'
+    - '**/*.log'
 
-  comment: on-failure
+  comment: never

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -25,3 +25,5 @@ sudo --preserve-env apt install -y \
   libprotobuf-dev \
   libprotobuf23 \
   protobuf-compiler
+
+pip install cmake-format

--- a/src/substrait/proto/update_proto_package.pl
+++ b/src/substrait/proto/update_proto_package.pl
@@ -1,4 +1,5 @@
 #!/bin/perl -w
+# SPDX-License-Identifier: Apache-2.0
 
 # Renames package declarations for protobuffers from substrait to substrait.proto.
 # This allows us to modify where the generated C++ have their definitions without

--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 #include <any>
 #include <map>
 #include <string>


### PR DESCRIPTION
Add lint to CI include checking for cmake-format, clang-format and license header, see https://github.com/substrait-io/substrait-cpp/issues/15