### PR TITLE
Add Decimal class to initially perform proto to string conversion.

### DIFF
--- a/include/substrait/common/Decimal.h
+++ b/include/substrait/common/Decimal.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "substrait/proto/algebra.pb.h"
+
+namespace io::substrait::common {
+
+class Decimal {
+  Decimal(std::string v, int32_t p, int32_t s)
+      : value_(std::move(v)), precision_(p), scale_(s) {}
+
+ public:
+  static Decimal fromProto(
+      const ::substrait::proto::Expression_Literal_Decimal& proto);
+
+  std::string toString();
+
+ private:
+  // Little-endian twos-complement integer representation of complete value
+  // (ignoring precision).  Always 16 bytes in length.
+  std::string value_;
+  // The maximum number of digits allowed in the value.
+  // the maximum precision is 38.
+  int32_t precision_;
+  // The declared scale of decimal literal
+  int32_t scale_;
+};
+
+} // namespace io::substrait::common

--- a/src/substrait/common/CMakeLists.txt
+++ b/src/substrait/common/CMakeLists.txt
@@ -10,6 +10,15 @@ target_link_libraries(
         substrait_common
         fmt::fmt-header-only)
 
+add_library(
+        substrait_types
+        Decimal.cpp
+)
+
+target_link_libraries(
+        substrait_types
+        substrait_proto)
+
 if (${SUBSTRAIT_CPP_BUILD_TESTING})
     add_subdirectory(tests)
 endif ()

--- a/src/substrait/common/Decimal.cpp
+++ b/src/substrait/common/Decimal.cpp
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "substrait/common/Decimal.h"
+
+namespace io::substrait::common {
+
+Decimal Decimal::fromProto(
+    const ::substrait::proto::Expression_Literal_Decimal& proto) {
+  return {proto.value(), proto.precision(), proto.scale()};
+};
+
+std::string Decimal::toString() {
+  if (value_.empty()) {
+    return "0";
+  }
+
+  int32_t numBytes = value_.size() & 0xFF;  // Enough for our 16 bytes.
+  bool isNegative = ((value_[numBytes - 1] & 0x80) != 0);
+
+  std::string decimalString;
+
+  unsigned long long value = 0;
+  for (int32_t i = numBytes - 1; i >= 0; i--) {
+    value = (value << 8) | static_cast<unsigned char>(value_[i]);
+    while (value > 10) {
+      decimalString += static_cast<char>('0' + (value % 10));
+      value /= 10;
+    }
+  }
+
+  while (value > 0) {
+    decimalString += static_cast<char>('0' + (value % 10));
+    value /= 10;
+  }
+
+  if (decimalString.empty()) {
+    return "0";
+  }
+
+  decimalString += "E" + std::to_string(scale_);
+  decimalString += "@precision=" + std::to_string(precision_);
+
+  if (isNegative) {
+    return "-" + decimalString;
+  }
+  return decimalString;
+}
+
+} // namespace io::substrait::common


### PR DESCRIPTION
This class requires discussion.

Do we need a generic class for manipulating the decimal datatype or do we already have one in the ecosystem?  My current needs are to convert from the substrait proto (::substrait::proto::Expression_Literal_Decimal) into a string form (and eventually back).  Would folks need to be able to perform actual operations with this class (basic arithmetic would be likely).

Once we figure out what we want this class to do (I expect massive changes) I'll add tests.