### PR TITLE
feat: functions and literals in text format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "third_party/fmt"]
 	path = third_party/fmt
 	url = https://github.com/fmtlib/fmt
+[submodule "third_party/abseil-cpp"]
+	path = third_party/abseil-cpp
+	url = https://github.com/abseil/abseil-cpp.git

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,6 +12,7 @@ header:
     - '.clang-tidy'
     - '.cmake-format'
     - '.licenserc.yaml'
+    - 'third_party/abseil-cpp'
     - 'third_party/fmt'
     - 'third_party/googletest'
     - 'third_party/substrait'

--- a/include/substrait/expression/DecimalLiteral.h
+++ b/include/substrait/expression/DecimalLiteral.h
@@ -5,7 +5,7 @@
 #include <string>
 
 namespace substrait::proto {
-  class Expression_Literal_Decimal;
+class Expression_Literal_Decimal;
 }
 
 namespace io::substrait::expression {
@@ -29,9 +29,13 @@ class DecimalLiteral {
   // a string.
   std::string toString();
 
-  [[nodiscard]] int32_t precision() const { return precision_; }
+  [[nodiscard]] int32_t precision() const {
+    return precision_;
+  }
 
-  [[nodiscard]] int32_t scale() const { return scale_; }
+  [[nodiscard]] int32_t scale() const {
+    return scale_;
+  }
 
  private:
   // Little-endian twos-complement integer representation of complete value
@@ -44,4 +48,4 @@ class DecimalLiteral {
   int32_t scale_;
 };
 
-} // namespace io::substrait::common
+} // namespace io::substrait::expression

--- a/include/substrait/expression/DecimalLiteral.h
+++ b/include/substrait/expression/DecimalLiteral.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <string>
+
+namespace substrait::proto {
+  class Expression_Literal_Decimal;
+}
+
+namespace io::substrait::expression {
+
+class DecimalLiteral {
+  DecimalLiteral(std::string v, int32_t p, int32_t s)
+      : value_(std::move(v)), precision_(p), scale_(s) {}
+
+ public:
+  static DecimalLiteral fromProto(
+      const ::substrait::proto::Expression_Literal_Decimal& proto);
+
+  // Validates that the constructed decimal has an exactly 16 byte value with
+  // a stated precision between 1 and 38.
+  bool isValid();
+
+  // Converts the value portion of the decimal to a string only.
+  std::string toBaseString();
+
+  // Converts the entirety of the decimal (including precision and scale) to
+  // a string.
+  std::string toString();
+
+  [[nodiscard]] int32_t precision() const { return precision_; }
+
+  [[nodiscard]] int32_t scale() const { return scale_; }
+
+ private:
+  // Little-endian twos-complement integer representation of complete value
+  // (ignoring precision).  Always 16 bytes in length.
+  std::string value_;
+  // The maximum number of digits allowed in the value.
+  // the maximum precision is 38.
+  int32_t precision_;
+  // The number of digits after the decimal point (may be negative).
+  int32_t scale_;
+};
+
+} // namespace io::substrait::common

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -18,6 +18,8 @@ sudo --preserve-env apt install -y \
   libprotobuf-dev \
   libprotobuf23 \
   protobuf-compiler \
-  clang-format
+  clang-format \
+  uuid-dev \
+  default-jre
 
 pip install cmake-format

--- a/src/substrait/CMakeLists.txt
+++ b/src/substrait/CMakeLists.txt
@@ -9,6 +9,7 @@ set(ADDITIONAL_CLEAN_FILES
 
 add_subdirectory(common)
 add_subdirectory(type)
+add_subdirectory(expression)
 add_subdirectory(function)
 add_subdirectory(proto)
 add_subdirectory(textplan)

--- a/src/substrait/expression/CMakeLists.txt
+++ b/src/substrait/expression/CMakeLists.txt
@@ -4,6 +4,6 @@ add_library(substrait_expression DecimalLiteral.cpp)
 
 target_link_libraries(substrait_expression substrait_proto absl::numeric)
 
-if (${SUBSTRAIT_CPP_BUILD_TESTING})
+if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
-endif ()
+endif()

--- a/src/substrait/expression/CMakeLists.txt
+++ b/src/substrait/expression/CMakeLists.txt
@@ -1,16 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_library(
-        substrait_expression
-        DecimalLiteral.cpp
-)
+add_library(substrait_expression DecimalLiteral.cpp)
 
-target_link_libraries(
-        substrait_expression
-        substrait_proto
-        absl::numeric
-)
+target_link_libraries(substrait_expression substrait_proto absl::numeric)
 
 if (${SUBSTRAIT_CPP_BUILD_TESTING})
-    add_subdirectory(tests)
+  add_subdirectory(tests)
 endif ()

--- a/src/substrait/expression/CMakeLists.txt
+++ b/src/substrait/expression/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(
+        substrait_expression
+        DecimalLiteral.cpp
+)
+
+target_link_libraries(
+        substrait_expression
+        substrait_proto
+        absl::numeric
+)
+
+if (${SUBSTRAIT_CPP_BUILD_TESTING})
+    add_subdirectory(tests)
+endif ()

--- a/src/substrait/expression/DecimalLiteral.cpp
+++ b/src/substrait/expression/DecimalLiteral.cpp
@@ -38,7 +38,6 @@ bool DecimalLiteral::isValid() {
   return value_.size() == 16 && precision_ >= 1 && precision_ <= 38;
 }
 
-
 std::string DecimalLiteral::toBaseString() {
   std::stringstream decimalString;
   if (value_.empty()) {
@@ -56,7 +55,7 @@ std::string DecimalLiteral::toBaseString() {
   }
 
   // Collect the bytes into an unsigned integer.
-  absl::uint128 value = 0;  // Will only hold 16 hex chars.
+  absl::uint128 value = 0; // Will only hold 16 hex chars.
   for (size_t i = numBytes; i > 0; i--) {
     value = (value << 8) | static_cast<unsigned char>(processingValue[i - 1]);
   }
@@ -93,4 +92,4 @@ std::string DecimalLiteral::toString() {
   return decimalString.str();
 }
 
-} // namespace io::substrait::common
+} // namespace io::substrait::expression

--- a/src/substrait/expression/DecimalLiteral.cpp
+++ b/src/substrait/expression/DecimalLiteral.cpp
@@ -11,8 +11,8 @@ namespace io::substrait::expression {
 
 namespace {
 
-// invertBits flips the sign of a two-complements value.
-std::string invertBits(const std::string& value) {
+// negate flips the sign of a two-complements value.
+std::string negate(const std::string& value) {
   std::string newValue = value;
   // Flip all of the bits and add one.
   bool carryover = true;
@@ -51,7 +51,7 @@ std::string DecimalLiteral::toBaseString() {
   bool isNegative = ((value_[numBytes - 1] & 0x80) != 0);
   if (isNegative) {
     decimalString << "-";
-    processingValue = invertBits(value_);
+    processingValue = negate(value_);
   }
 
   // Collect the bytes into an unsigned integer.

--- a/src/substrait/expression/DecimalLiteral.cpp
+++ b/src/substrait/expression/DecimalLiteral.cpp
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "substrait/expression/DecimalLiteral.h"
+
+#include <sstream>
+
+#include "absl/numeric/int128.h"
+#include "substrait/proto/algebra.pb.h"
+
+namespace io::substrait::expression {
+
+namespace {
+
+// invertBits flips the sign of a two-complements value.
+std::string invertBits(const std::string& value) {
+  std::string newValue = value;
+  // Flip all of the bits and add one.
+  bool carryover = true;
+  for (char& b : newValue) {
+    uint8_t newB = ~(static_cast<uint8_t>(b));
+    if (carryover) {
+      newB++;
+    }
+    carryover = carryover && (newB == 0);
+    b = static_cast<char>(newB & 0xff);
+  }
+  return newValue;
+}
+
+} // namespace
+
+DecimalLiteral DecimalLiteral::fromProto(
+    const ::substrait::proto::Expression_Literal_Decimal& proto) {
+  return {proto.value(), proto.precision(), proto.scale()};
+}
+
+bool DecimalLiteral::isValid() {
+  return value_.size() == 16 && precision_ >= 1 && precision_ <= 38;
+}
+
+
+std::string DecimalLiteral::toBaseString() {
+  std::stringstream decimalString;
+  if (value_.empty()) {
+    return "0";
+  }
+
+  std::string processingValue = value_;
+
+  // Determine the sign of the value.
+  size_t numBytes = value_.size();
+  bool isNegative = ((value_[numBytes - 1] & 0x80) != 0);
+  if (isNegative) {
+    decimalString << "-";
+    processingValue = invertBits(value_);
+  }
+
+  // Collect the bytes into an unsigned integer.
+  absl::uint128 value = 0;  // Will only hold 16 hex chars.
+  for (size_t i = numBytes; i > 0; i--) {
+    value = (value << 8) | static_cast<unsigned char>(processingValue[i - 1]);
+  }
+
+  // Pull off the digits backwards.
+  std::stringstream valueString;
+  while (value >= 10) {
+    valueString << static_cast<char>('0' + (value % 10));
+    value /= 10;
+  }
+  valueString << static_cast<char>('0' + value);
+
+  // Reverse the digits.
+  std::string v = valueString.str();
+  for (auto c = v.rbegin(); c != v.rend(); c++) {
+    decimalString << *c;
+  }
+
+  return decimalString.str();
+}
+
+std::string DecimalLiteral::toString() {
+  std::stringstream decimalString;
+
+  decimalString << toBaseString();
+
+  if (scale_ > 0) {
+    decimalString << "E-" << scale_;
+  } else if (scale_ < 0) {
+    decimalString << "E+" << -scale_;
+  }
+  decimalString << "@precision=" << precision_;
+
+  return decimalString.str();
+}
+
+} // namespace io::substrait::common

--- a/src/substrait/expression/tests/CMakeLists.txt
+++ b/src/substrait/expression/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_test_case(
+        substrait_expression_test
+        SOURCES
+        DecimalTest.cpp
+        EXTRA_LINK_LIBS
+        substrait_expression
+        gmock
+        gtest
+        gtest_main)

--- a/src/substrait/expression/tests/CMakeLists.txt
+++ b/src/substrait/expression/tests/CMakeLists.txt
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_test_case(
-        substrait_expression_test
-        SOURCES
-        DecimalTest.cpp
-        EXTRA_LINK_LIBS
-        substrait_expression
-        gmock
-        gtest
-        gtest_main)
+  substrait_expression_test
+  SOURCES
+  DecimalTest.cpp
+  EXTRA_LINK_LIBS
+  substrait_expression
+  gmock
+  gtest
+  gtest_main)

--- a/src/substrait/expression/tests/DecimalTest.cpp
+++ b/src/substrait/expression/tests/DecimalTest.cpp
@@ -19,7 +19,7 @@ class TestCase {
 };
 
 static DecimalLiteral
-createDecimal(std::string value, int32_t scale, int32_t precision) {
+createDecimal(const std::string& value, int32_t scale, int32_t precision) {
   ::substrait::proto::Expression_Literal_Decimal proto;
   proto.set_value(value);
   proto.set_precision(precision);
@@ -29,22 +29,28 @@ createDecimal(std::string value, int32_t scale, int32_t precision) {
 
 class DecimalTest : public ::testing::TestWithParam<TestCase> {};
 
-std::vector<TestCase> GetTestCases() {
+std::vector<TestCase> getTestCases() {
   static std::vector<TestCase> cases = {
-      {"42noscale", createDecimal("\x2A", 0, 3), false, "42@precision=3"},
+      {"42noscale",
+       createDecimal("\x2A", 0, 3), // NOLINT
+       false,
+       "42@precision=3"},
       {"42positivescale",
-       createDecimal("\x2A", +2, 3),
+       createDecimal("\x2A", +2, 3), // NOLINT
        false,
        "42E-2@precision=3"},
       {"42negativescale",
-       createDecimal("\x2A", -2, 3),
+       createDecimal("\x2A", -2, 3), // NOLINT
        false,
        "42E+2@precision=3"},
 
       {"8bit, 0", createDecimal({"\x00", 1}, 0, 4), false, "0@precision=4"},
       {"8bit, 1", createDecimal("\x01", 0, 4), false, "1@precision=4"},
       {"8bit, 2", createDecimal("\x02", 0, 4), false, "2@precision=4"},
-      {"8bit, 126", createDecimal("\x7E", 0, 4), false, "126@precision=4"},
+      {"8bit, 126",
+       createDecimal("\x7E", 0, 4), // NOLINT
+       false,
+       "126@precision=4"},
       {"8bit, 127", createDecimal("\x7F", 0, 4), false, "127@precision=4"},
       {"8bit, 128", createDecimal("\x80", 0, 4), false, "-128@precision=4"},
       {"8bit, 129", createDecimal("\x81", 0, 4), false, "-127@precision=4"},
@@ -62,7 +68,7 @@ std::vector<TestCase> GetTestCases() {
        false,
        "128@precision=4"},
       {"16bit, 33333",
-       createDecimal("\x39\x30", 0, 4),
+       createDecimal("\x39\x30", 0, 4), // NOLINT
        false,
        "12345@precision=4"},
       {"16bit, 53191",
@@ -156,7 +162,7 @@ TEST_P(DecimalTest, toString) {
 INSTANTIATE_TEST_SUITE_P(
     DecimalTests,
     DecimalTest,
-    ::testing::ValuesIn(GetTestCases()),
+    ::testing::ValuesIn(getTestCases()),
     [](const testing::TestParamInfo<TestCase>& info) {
       std::string identifier = info.param.name;
       // Remove non-alphanumeric characters to make the test framework happy.

--- a/src/substrait/expression/tests/DecimalTest.cpp
+++ b/src/substrait/expression/tests/DecimalTest.cpp
@@ -1,0 +1,172 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "substrait/expression/DecimalLiteral.h"
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "substrait/proto/algebra.pb.h"
+
+namespace io::substrait::expression {
+
+class TestCase {
+ public:
+  std::string name;
+  DecimalLiteral input;
+
+  bool expectedValidity;
+  std::string expectedValue;
+};
+
+static DecimalLiteral
+createDecimal(std::string value, int32_t scale, int32_t precision) {
+  ::substrait::proto::Expression_Literal_Decimal proto;
+  proto.set_value(value);
+  proto.set_precision(precision);
+  proto.set_scale(scale);
+  return DecimalLiteral::fromProto(proto);
+}
+
+class DecimalTest : public ::testing::TestWithParam<TestCase> {};
+
+std::vector<TestCase> GetTestCases() {
+  static std::vector<TestCase> cases = {
+      {"42noscale", createDecimal("\x2A", 0, 3), false, "42@precision=3"},
+      {"42positivescale",
+       createDecimal("\x2A", +2, 3),
+       false,
+       "42E-2@precision=3"},
+      {"42negativescale",
+       createDecimal("\x2A", -2, 3),
+       false,
+       "42E+2@precision=3"},
+
+      {"8bit, 0", createDecimal({"\x00", 1}, 0, 4), false, "0@precision=4"},
+      {"8bit, 1", createDecimal("\x01", 0, 4), false, "1@precision=4"},
+      {"8bit, 2", createDecimal("\x02", 0, 4), false, "2@precision=4"},
+      {"8bit, 126", createDecimal("\x7E", 0, 4), false, "126@precision=4"},
+      {"8bit, 127", createDecimal("\x7F", 0, 4), false, "127@precision=4"},
+      {"8bit, 128", createDecimal("\x80", 0, 4), false, "-128@precision=4"},
+      {"8bit, 129", createDecimal("\x81", 0, 4), false, "-127@precision=4"},
+      {"8bit, 130", createDecimal("\x82", 0, 4), false, "-126@precision=4"},
+      {"8bit, 254", createDecimal("\xFE", 0, 4), false, "-2@precision=4"},
+      {"8bit, 255", createDecimal("\xFF", 0, 4), false, "-1@precision=4"},
+
+      {"16bit, 2", createDecimal("\x02", 0, 4), false, "2@precision=4"},
+      {"16bit, 127",
+       createDecimal({"\x7F\x00", 2}, 0, 4),
+       false,
+       "127@precision=4"},
+      {"16bit, 128",
+       createDecimal({"\x80\x00", 2}, 0, 4),
+       false,
+       "128@precision=4"},
+      {"16bit, 33333",
+       createDecimal("\x39\x30", 0, 4),
+       false,
+       "12345@precision=4"},
+      {"16bit, 53191",
+       createDecimal("\xC7\xCF", 0, 4),
+       false,
+       "-12345@precision=4"},
+      {"16bit, 65534",
+       createDecimal("\xFE\xFF", 0, 4),
+       false,
+       "-2@precision=4"},
+      {"16bit, 65535",
+       createDecimal("\xFF\xFF", 0, 4),
+       false,
+       "-1@precision=4"},
+
+      {"propersize",
+       createDecimal(
+           "\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78",
+           -2,
+           31),
+       true,
+       "159954953172672629770948536149615195154E+2@precision=31"},
+      {"zeroprecision",
+       createDecimal(
+           "\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78",
+           -2,
+           0),
+       false,
+       "159954953172672629770948536149615195154E+2@precision=0"},
+      {"negativeprecision",
+       createDecimal(
+           "\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78",
+           -2,
+           -2),
+       false,
+       "159954953172672629770948536149615195154E+2@precision=-2"},
+      {"largeprecision",
+       createDecimal(
+           "\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78",
+           -2,
+           42),
+       false,
+       "159954953172672629770948536149615195154E+2@precision=42"},
+
+      {"zero",
+       createDecimal(
+           {"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+            16},
+           2,
+           31),
+       true,
+       "0E-2@precision=31"},
+      {"minint",
+       createDecimal(
+           {"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80",
+            16},
+           0,
+           38),
+       true,
+       "-170141183460469231731687303715884105728@precision=38"},
+      {"maxint",
+       createDecimal(
+           {"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x7f",
+            16},
+           0,
+           38),
+       true,
+       "170141183460469231731687303715884105727@precision=38"},
+      {"negativeone",
+       createDecimal(
+           {"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+            16},
+           2,
+           31),
+       true,
+       "-1E-2@precision=31"},
+  };
+  return cases;
+}
+
+TEST_P(DecimalTest, isValid) {
+  auto [name, decimal, expectedValidity, _] = GetParam();
+  ASSERT_THAT(decimal.isValid(), ::testing::Eq(expectedValidity));
+}
+
+TEST_P(DecimalTest, toString) {
+  auto [name, decimal, _, expectedValue] = GetParam();
+  ASSERT_THAT(decimal.toString(), ::testing::Eq(expectedValue));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DecimalTests,
+    DecimalTest,
+    ::testing::ValuesIn(GetTestCases()),
+    [](const testing::TestParamInfo<TestCase>& info) {
+      std::string identifier = info.param.name;
+      // Remove non-alphanumeric characters to make the test framework happy.
+      identifier.erase(
+          std::remove_if(
+              identifier.begin(),
+              identifier.end(),
+              [](auto const& c) -> bool { return !std::isalnum(c); }),
+          identifier.end());
+      return identifier;
+    });
+
+}  // namespace io::substrait::expression

--- a/src/substrait/expression/tests/DecimalTest.cpp
+++ b/src/substrait/expression/tests/DecimalTest.cpp
@@ -169,4 +169,4 @@ INSTANTIATE_TEST_SUITE_P(
       return identifier;
     });
 
-}  // namespace io::substrait::expression
+} // namespace io::substrait::expression

--- a/src/substrait/textplan/Location.cpp
+++ b/src/substrait/textplan/Location.cpp
@@ -6,7 +6,7 @@
 
 namespace io::substrait::textplan {
 
-constexpr const Location Location::kUnknownLocation(
+constexpr Location Location::kUnknownLocation(
     static_cast<google::protobuf::Message*>(nullptr));
 
 bool operator==(const Location& c1, const Location& c2) {

--- a/src/substrait/textplan/Location.cpp
+++ b/src/substrait/textplan/Location.cpp
@@ -6,7 +6,7 @@
 
 namespace io::substrait::textplan {
 
-const Location Location::kUnknownLocation(
+constexpr const Location Location::kUnknownLocation(
     static_cast<google::protobuf::Message*>(nullptr));
 
 bool operator==(const Location& c1, const Location& c2) {

--- a/src/substrait/textplan/Location.h
+++ b/src/substrait/textplan/Location.h
@@ -54,6 +54,5 @@ struct std::less<::io::substrait::textplan::Location> {
 };
 
 // Convenience macro useful for construction protobuffer based locations.
-#define PROTO_LOCATION(proto) \
+#define PROTO_LOCATION(proto)                                                  \
   ::io::substrait::textplan::Location((::google::protobuf::Message*)&proto)
-

--- a/src/substrait/textplan/Location.h
+++ b/src/substrait/textplan/Location.h
@@ -52,3 +52,8 @@ struct std::less<::io::substrait::textplan::Location> {
       const ::io::substrait::textplan::Location& lhs,
       const ::io::substrait::textplan::Location& rhs) const noexcept;
 };
+
+// Convenience macro useful for construction protobuffer based locations.
+#define PROTO_LOCATION(proto) \
+  ::io::substrait::textplan::Location((::google::protobuf::Message*)&proto)
+

--- a/src/substrait/textplan/Location.h
+++ b/src/substrait/textplan/Location.h
@@ -55,4 +55,4 @@ struct std::less<::io::substrait::textplan::Location> {
 
 // Convenience macro useful for construction protobuffer based locations.
 #define PROTO_LOCATION(proto)                                                  \
-  ::io::substrait::textplan::Location((::google::protobuf::Message*)&proto)
+  ::io::substrait::textplan::Location((::google::protobuf::Message*)&(proto))

--- a/src/substrait/textplan/SubstraitErrorListener.cpp
+++ b/src/substrait/textplan/SubstraitErrorListener.cpp
@@ -17,6 +17,11 @@ void SubstraitErrorListener::addError(
 std::vector<std::string> SubstraitErrorListener::getErrorMessages() {
   std::vector<std::string> messages;
   for (const auto& instance : getErrors()) {
+    if (instance.location.line == -1 ||
+        instance.location.charPositionInLine == -1) {
+      messages.push_back(instance.message);
+      continue;
+    }
     messages.push_back(
         std::to_string(instance.location.line) + ":" +
         std::to_string(instance.location.charPositionInLine) + " → " +

--- a/src/substrait/textplan/SubstraitErrorListener.h
+++ b/src/substrait/textplan/SubstraitErrorListener.h
@@ -25,7 +25,10 @@ class SubstraitErrorListener {
   SubstraitErrorListener() = default;
 
   void addError(size_t linenum, size_t charnum, const std::string& msg);
-  void addError(const std::string& msg) { addError(-1, -1, msg); };
+
+  void addError(const std::string& msg) {
+    addError(-1, -1, msg);
+  };
 
   const std::vector<ErrorInstance>& getErrors() {
     return errors_;

--- a/src/substrait/textplan/SubstraitErrorListener.h
+++ b/src/substrait/textplan/SubstraitErrorListener.h
@@ -25,6 +25,7 @@ class SubstraitErrorListener {
   SubstraitErrorListener() = default;
 
   void addError(size_t linenum, size_t charnum, const std::string& msg);
+  void addError(const std::string& msg) { addError(-1, -1, msg); };
 
   const std::vector<ErrorInstance>& getErrors() {
     return errors_;

--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -10,7 +10,7 @@
 
 namespace io::substrait::textplan {
 
-const std::string& SymbolTypeName(SymbolType type) {
+const std::string& symbolTypeName(SymbolType type) {
   static std::vector<std::string> names = {
       "kExtensionSpace",
       "kFunction",

--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -5,9 +5,38 @@
 #include <map>
 #include <string>
 
+#include "SymbolTable.h"
+
+#include "substrait/common/Exceptions.h"
 #include "substrait/textplan/Location.h"
 
 namespace io::substrait::textplan {
+
+const std::string& SymbolTypeName(SymbolType type) {
+  static std::vector<std::string> names = {
+      "kExtensionSpace",
+      "kFunction",
+      "kPlanRelation",
+      "kRelation",
+      "kRelationDetail",
+      "kSchema",
+      "kSchemaColumn",
+      "kSource",
+      "kSourceDetail",
+      "kField",
+  };
+  auto typeNum = int32_t(type);
+  if (typeNum == -1) {
+    static std::string unknown = "kUnknown";
+    return unknown;
+  }
+  if (typeNum > names.size()) {
+    SUBSTRAIT_FAIL(
+        "Unknown symbol type " + std::to_string(typeNum) + " referenced.");
+  }
+
+  return names[typeNum];
+}
 
 bool SymbolTableIterator::operator!=(SymbolTableIterator const& other) const {
   return index_ != other.index_;
@@ -21,6 +50,13 @@ SymbolTableIterator SymbolTableIterator::operator++() {
   ++index_;
   return *this;
 }
+
+const SymbolInfo SymbolInfo::kUnknown = {
+    "__UNKNOWN__",
+    Location::kUnknownLocation,
+    SymbolType::kUnknown,
+    std::nullopt,
+    std::nullopt};
 
 bool operator==(const SymbolInfo& left, const SymbolInfo& right) {
   return (left.name == right.name) && (left.location == right.location) &&
@@ -71,7 +107,7 @@ SymbolInfo* SymbolTable::defineUniqueSymbol(
 const SymbolInfo& SymbolTable::lookupSymbolByName(const std::string& name) {
   auto itr = symbolsByName_.find(name);
   if (itr == symbolsByName_.end()) {
-    return kUnknownSymbol;
+    return SymbolInfo::kUnknown;
   }
   return *symbols_[itr->second];
 }
@@ -80,7 +116,7 @@ const SymbolInfo& SymbolTable::lookupSymbolByLocation(
     const Location& location) {
   auto itr = symbolsByLocation_.find(location);
   if (itr == symbolsByLocation_.end()) {
-    return kUnknownSymbol;
+    return SymbolInfo::kUnknown;
   }
   return *symbols_[itr->second];
 }
@@ -94,7 +130,7 @@ const SymbolInfo& SymbolTable::nthSymbolByType(uint32_t n, SymbolType type) {
       }
     }
   }
-  return kUnknownSymbol;
+  return SymbolInfo::kUnknown;
 }
 
 SymbolTableIterator SymbolTable::begin() const {
@@ -104,12 +140,5 @@ SymbolTableIterator SymbolTable::begin() const {
 SymbolTableIterator SymbolTable::end() const {
   return {this, symbolsByName_.size()};
 }
-
-const SymbolInfo SymbolTable::kUnknownSymbol = {
-    "__UNKNOWN__",
-    Location::kUnknownLocation,
-    SymbolType::kUnknown,
-    std::nullopt,
-    std::nullopt};
 
 } // namespace io::substrait::textplan

--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -5,8 +5,6 @@
 #include <map>
 #include <string>
 
-#include "SymbolTable.h"
-
 #include "substrait/common/Exceptions.h"
 #include "substrait/textplan/Location.h"
 

--- a/src/substrait/textplan/SymbolTable.h
+++ b/src/substrait/textplan/SymbolTable.h
@@ -65,7 +65,7 @@ enum class SourceType {
   kExtensionTable = 4,
 };
 
-const std::string& SymbolTypeName(SymbolType type);
+const std::string& symbolTypeName(SymbolType type);
 
 struct SymbolInfo {
   std::string name;

--- a/src/substrait/textplan/SymbolTable.h
+++ b/src/substrait/textplan/SymbolTable.h
@@ -65,6 +65,8 @@ enum class SourceType {
   kExtensionTable = 4,
 };
 
+const std::string& SymbolTypeName(SymbolType type);
+
 struct SymbolInfo {
   std::string name;
   Location location;
@@ -83,6 +85,8 @@ struct SymbolInfo {
         type(newType),
         subtype(std::move(newSubtype)),
         blob(std::move(newBlob)){};
+
+  static const SymbolInfo kUnknown;
 
   friend bool operator==(const SymbolInfo& left, const SymbolInfo& right);
   friend bool operator!=(const SymbolInfo& left, const SymbolInfo& right);
@@ -149,19 +153,17 @@ class SymbolTable {
   // Add the capability for ::testing::PrintToString to print this.
   friend std::ostream& operator<<(std::ostream& os, const SymbolTable& result) {
     os << std::string("{");
-    bool outputFirst = false;
+    bool hasPreviousText = false;
     for (const auto& symbol : result.getSymbols()) {
-      if (outputFirst) {
+      if (hasPreviousText) {
         os << std::string(", ");
       }
       os << symbol->name;
-      outputFirst = true;
+      hasPreviousText = true;
     }
     os << std::string("}");
     return os;
   }
-
-  static const SymbolInfo kUnknownSymbol;
 
  private:
   friend SymbolTableIterator;

--- a/src/substrait/textplan/SymbolTablePrinter.cpp
+++ b/src/substrait/textplan/SymbolTablePrinter.cpp
@@ -297,8 +297,9 @@ std::string outputFunctionsSection(const SymbolTable& symbolTable) {
   // Finally output the extensions by space in the order they were encountered.
   bool hasPreviousOutput = false;
   for (const uint32_t space : usedSpaces) {
-    if (hasPreviousOutput)
+    if (hasPreviousOutput) {
       text << "\n";
+    }
     if (spaceNames.find(space) == spaceNames.end()) {
       // TODO: Handle this case as a warning.
       text << "extension_space {\n";

--- a/src/substrait/textplan/SymbolTablePrinter.cpp
+++ b/src/substrait/textplan/SymbolTablePrinter.cpp
@@ -156,7 +156,7 @@ std::string relationToText(
   auto relation = ANY_CAST(const ::substrait::proto::Rel*, info.blob);
 
   PlanPrinterVisitor printer(symbolTable);
-  return printer.printRelation(info.name, relation);
+  return printer.printRelation(relation);
 }
 
 std::string outputPipelinesSection(const SymbolTable& symbolTable) {
@@ -295,7 +295,10 @@ std::string outputFunctionsSection(const SymbolTable& symbolTable) {
   }
 
   // Finally output the extensions by space in the order they were encountered.
+  bool hasPreviousOutput = false;
   for (const uint32_t space : usedSpaces) {
+    if (hasPreviousOutput)
+      text << "\n";
     if (spaceNames.find(space) == spaceNames.end()) {
       // TODO: Handle this case as a warning.
       text << "extension_space {\n";
@@ -320,6 +323,7 @@ std::string outputFunctionsSection(const SymbolTable& symbolTable) {
            << ";\n";
     }
     text << "}\n";
+    hasPreviousOutput = true;
   }
 
   return text.str();

--- a/src/substrait/textplan/converter/CMakeLists.txt
+++ b/src/substrait/textplan/converter/CMakeLists.txt
@@ -15,11 +15,8 @@ set(TEXTPLAN_SRCS
 add_library(substrait_textplan_converter ${TEXTPLAN_SRCS})
 
 target_link_libraries(
-  substrait_textplan_converter
-  substrait_common
-  substrait_expression
-  substrait_proto
-  symbol_table error_listener)
+  substrait_textplan_converter substrait_common substrait_expression
+  substrait_proto symbol_table error_listener)
 
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)

--- a/src/substrait/textplan/converter/CMakeLists.txt
+++ b/src/substrait/textplan/converter/CMakeLists.txt
@@ -14,8 +14,12 @@ set(TEXTPLAN_SRCS
 
 add_library(substrait_textplan_converter ${TEXTPLAN_SRCS})
 
-target_link_libraries(substrait_textplan_converter substrait_common
-                      substrait_proto symbol_table error_listener)
+target_link_libraries(
+  substrait_textplan_converter
+  substrait_common
+  substrait_expression
+  substrait_proto
+  symbol_table error_listener)
 
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)

--- a/src/substrait/textplan/converter/InitialPlanProtoVisitor.h
+++ b/src/substrait/textplan/converter/InitialPlanProtoVisitor.h
@@ -53,6 +53,9 @@ class InitialPlanProtoVisitor : public BasePlanProtoVisitor {
   std::any visitExtensionTable(
       const ::substrait::proto::ReadRel_ExtensionTable& table) override;
 
+  std::any visitNamedStruct(
+      const ::substrait::proto::NamedStruct& named) override;
+
   std::shared_ptr<SymbolTable> symbolTable_;
   std::shared_ptr<SubstraitErrorListener> errorListener_;
 };

--- a/src/substrait/textplan/converter/PlanPrinterVisitor.cpp
+++ b/src/substrait/textplan/converter/PlanPrinterVisitor.cpp
@@ -3,33 +3,51 @@
 #include "substrait/textplan/converter/PlanPrinterVisitor.h"
 
 #include <iterator>
-#include <optional>
 #include <sstream>
 #include <string>
 
+#include "substrait/expression/DecimalLiteral.h"
 #include "substrait/proto/ProtoUtils.h"
 #include "substrait/proto/algebra.pb.h"
 #include "substrait/textplan/Any.h"
 
 namespace io::substrait::textplan {
 
+namespace {
+
+std::string stringEscape(std::string_view str) {
+  // TODO - Implement all of the escapes defined in the document.
+  std::stringstream result;
+  for (auto c : str) {
+    if (c == '"') {
+      result << '\\';
+    }
+    result << c;
+  }
+  return result.str();
+}
+
+} // namespace
+
 std::string PlanPrinterVisitor::printRelation(
-    const std::string& symbolName,
     const ::substrait::proto::Rel* relation) {
   std::stringstream text;
-
+  auto symbol = symbolTable_->lookupSymbolByLocation(PROTO_LOCATION(*relation));
   text << ::substrait::proto::relTypeCaseName(relation->rel_type_case())
-       << " relation " << symbolName << " {\n";
-  auto symbol = symbolTable_->lookupSymbolByLocation(
-      Location((google::protobuf::Message*)&relation));
+       << " relation " << symbol.name << " {\n";
+
+#if 0
   if (symbol != SymbolTable::kUnknownSymbol) {
     text << "  source " << symbol.name << ";\n";
   }
+#endif
   auto result = this->visitRelation(*relation);
   if (result.type() != typeid(std::string)) {
-    return "ERROR:  Relation subtype " +
+    errorListener_->addError(
+        "ERROR:  Relation subtype " +
         ::substrait::proto::relTypeCaseName((relation->rel_type_case())) +
-        " not supported!\n";
+        " not supported!");
+    return "";
   }
   text << ANY_CAST(std::string, result);
   text << "}\n";
@@ -37,29 +55,544 @@ std::string PlanPrinterVisitor::printRelation(
   return text.str();
 }
 
-std::any PlanPrinterVisitor::visitAggregateFunction(
-    const ::substrait::proto::AggregateFunction& function) {
-  return std::string("AF-NOT-YET-IMPLEMENTED");
+std::string PlanPrinterVisitor::lookupFieldReference(uint32_t field_reference) {
+  auto field =
+      symbolTable_->nthSymbolByType(field_reference, SymbolType::kField);
+  if (field != SymbolInfo::kUnknown) {
+    return field.name;
+  } else {
+    errorListener_->addError(
+        "Field number " + std::to_string(field_reference) +
+        " referenced but not defined.");
+    return "field#" + std::to_string(field_reference);
+  }
 }
 
-std::any PlanPrinterVisitor::visitExpression(
-    const ::substrait::proto::Expression& expression) {
-  return std::string("EXPR-NOT-YET-IMPLEMENTED");
+std::string PlanPrinterVisitor::lookupFunctionReference(
+    uint32_t function_reference) {
+  for (const auto& symbol : symbolTable_->getSymbols()) {
+    if (symbol->type != SymbolType::kFunction) {
+      continue;
+    }
+    auto function = ANY_CAST(
+        const ::substrait::proto::extensions::
+            SimpleExtensionDeclaration_ExtensionFunction*,
+        symbol->blob);
+    if (function->function_anchor() == function_reference) {
+      return symbol->name;
+    }
+  }
+  errorListener_->addError(
+      "Reference of undefined function " + std::to_string(function_reference) +
+      " encountered.");
+  return "functionref#" + std::to_string(function_reference);
+}
+
+std::any PlanPrinterVisitor::visitSelect(
+    const ::substrait::proto::Expression_MaskExpression_Select& select) {
+  errorListener_->addError("MaskExpression Select not yet implemented.");
+  return std::string("MASKSELECT_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitType(const ::substrait::proto::Type& type) {
+  switch (type.kind_case()) {
+    case ::substrait::proto::Type::kBool:
+      if (type.bool_().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_bool");
+      }
+      return std::string("bool");
+    case ::substrait::proto::Type::kI8:
+      if (type.i8().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_i8");
+      }
+      return std::string("i8");
+    case ::substrait::proto::Type::kI16:
+      if (type.i16().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_i16");
+      }
+      return std::string("i16");
+    case ::substrait::proto::Type::kI32:
+      if (type.i32().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_i32");
+      }
+      return std::string("i32");
+    case ::substrait::proto::Type::kI64:
+      if (type.i64().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_i64");
+      }
+      return std::string("i64");
+    case ::substrait::proto::Type::kFp32:
+      if (type.fp32().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_fp32");
+      }
+      return std::string("fp32");
+    case ::substrait::proto::Type::kFp64:
+      if (type.fp64().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_fp64");
+      }
+      return std::string("fp64");
+    case ::substrait::proto::Type::kString:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_string");
+      }
+      return std::string("string");
+    case ::substrait::proto::Type::kDecimal:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return std::string("opt_decimal");
+      }
+      return std::string("decimal");
+    case ::substrait::proto::Type::kVarchar:
+      return std::string("varchar");
+    case ::substrait::proto::Type::kFixedChar:
+      return std::string("fixedchar");
+    case ::substrait::proto::Type::kDate:
+      return std::string("date");
+    case ::substrait::proto::Type::KIND_NOT_SET:
+      errorListener_->addError(
+          "Invalid type message -- type was not included.");
+      return std::string("MISSING_TYPE");
+    case ::substrait::proto::Type::kBinary:
+    case ::substrait::proto::Type::kTimestamp:
+    case ::substrait::proto::Type::kTime:
+    case ::substrait::proto::Type::kIntervalYear:
+    case ::substrait::proto::Type::kIntervalDay:
+    case ::substrait::proto::Type::kTimestampTz:
+    case ::substrait::proto::Type::kUuid:
+    case ::substrait::proto::Type::kFixedBinary:
+    case ::substrait::proto::Type::kStruct:
+    case ::substrait::proto::Type::kList:
+    case ::substrait::proto::Type::kMap:
+    case ::substrait::proto::Type::kUserDefined:
+    case ::substrait::proto::Type::kUserDefinedTypeReference:
+      errorListener_->addError(
+          "Unsupported type requested: " + type.ShortDebugString());
+      return std::string("UNSUPPORTED_TYPE");
+  }
+  errorListener_->addError(
+      "New unspported type requested: " + type.ShortDebugString());
+  return std::string("UNSUPPORTED_TYPE");
+}
+
+std::any PlanPrinterVisitor::visitStruct(
+    const ::substrait::proto::Type_Struct& structure) {
+  // TODO -- Implement.
+  errorListener_->addError("Struct types are not yet supported.");
+  return std::string("STRUCT_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitLiteral(
+    const ::substrait::proto::Expression::Literal& literal) {
+  std::stringstream text;
+  switch (literal.literal_type_case()) {
+    case ::substrait::proto::Expression::Literal::kBoolean:
+      text << literal.boolean();
+      break;
+    case ::substrait::proto::Expression::Literal::kI8:
+      text << literal.i8() << "_i8";
+      break;
+    case ::substrait::proto::Expression::Literal::kI16:
+      text << literal.i16() << "_i16";
+      break;
+    case ::substrait::proto::Expression::Literal::kI32:
+      text << literal.i32() << "_i32";
+      break;
+    case ::substrait::proto::Expression::Literal::kI64:
+      text << literal.i64() << "_i64";
+      break;
+    case ::substrait::proto::Expression::Literal::kFp32:
+      text << literal.fp32() << "_fp32";
+      break;
+    case ::substrait::proto::Expression::Literal::kFp64:
+      text << literal.fp64() << "_fp64";
+      break;
+    case ::substrait::proto::Expression::Literal ::kDate: {
+      // TODO -- Format this as a date instead of a delta since an epoch.
+      if (literal.date() >= 0) {
+        text << "\"epoch+" << literal.date() << " days\"_date";
+      } else {
+        text << "\"epoch" << literal.date() << " days\"_date";
+      }
+      break;
+    }
+    case ::substrait::proto::Expression::Literal::kString:
+      text << "\"" << stringEscape(literal.string()) << "\"_string";
+      break;
+    case ::substrait::proto::Expression_Literal::kBinary:
+    case ::substrait::proto::Expression_Literal::kTimestamp:
+    case ::substrait::proto::Expression_Literal::kTime:
+      errorListener_->addError(
+          "Literal of this type not yet supported: " +
+          literal.ShortDebugString());
+      return std::string("UNSUPPORTED_LITERAL_TYPE");
+    case ::substrait::proto::Expression_Literal::kIntervalYearToMonth: {
+      text << "{";
+      bool hasPreviousText = false;
+      if (literal.interval_year_to_month().years() != 0) {
+        text << literal.interval_year_to_month().years() << "years";
+        hasPreviousText = true;
+      }
+      if (literal.interval_year_to_month().months() != 0) {
+        if (hasPreviousText) {
+          text << ", ";
+        }
+        text << literal.interval_year_to_month().months() << "months";
+      }
+      text << "}_interval_year"; // TODO - Change spec to better name.
+      break;
+    }
+    case ::substrait::proto::Expression_Literal::kIntervalDayToSecond: {
+      text << "{";
+      bool hasPreviousText = false;
+      if (literal.interval_day_to_second().days() != 0) {
+        text << literal.interval_day_to_second().days() << "days";
+        hasPreviousText = true;
+      }
+      if (literal.interval_day_to_second().seconds() != 0) {
+        if (hasPreviousText) {
+          text << ", ";
+        }
+        text << literal.interval_day_to_second().seconds() << "seconds";
+        hasPreviousText = true;
+      }
+      if (literal.interval_day_to_second().microseconds() != 0) {
+        if (hasPreviousText) {
+          text << ", ";
+        }
+        text << literal.interval_day_to_second().microseconds()
+             << "microseconds";
+      }
+      text << "}_interval_day"; // TODO - Change spec to better name.
+      break;
+    }
+    case ::substrait::proto::Expression_Literal::kFixedChar:
+      // TODO - Consider dropping the length in the type in favor of strlen.
+      text << "\"" << stringEscape(literal.fixed_char()) << "\"_fixedchar<"
+           << literal.fixed_char().length() << ">";
+      break;
+    case ::substrait::proto::Expression_Literal::kVarChar:
+      text << "\"" << stringEscape(literal.var_char().value()) << "\"_varchar<"
+           << literal.var_char().length() << ">";
+      break;
+    case ::substrait::proto::Expression_Literal::kDecimal: {
+      auto dec = expression::DecimalLiteral::fromProto(literal.decimal());
+      text << dec.toBaseString();
+      text << "_decimal<" << dec.precision() << "," << dec.scale() << ">";
+      break;
+    }
+    case ::substrait::proto::Expression_Literal::kFixedBinary:
+    case ::substrait::proto::Expression_Literal::kStruct:
+    case ::substrait::proto::Expression_Literal::kMap:
+    case ::substrait::proto::Expression_Literal::kTimestampTz:
+    case ::substrait::proto::Expression_Literal::kUuid:
+    case ::substrait::proto::Expression_Literal::kNull:
+    case ::substrait::proto::Expression_Literal::kList:
+    case ::substrait::proto::Expression_Literal::kEmptyList:
+    case ::substrait::proto::Expression_Literal::kEmptyMap:
+    case ::substrait::proto::Expression_Literal::kUserDefined:
+      errorListener_->addError(
+          "Literal of this type not yet supported: " +
+          literal.ShortDebugString());
+      return std::string("UNSUPPORTED_LITERAL_TYPE");
+    case ::substrait::proto::Expression::Literal::LITERAL_TYPE_NOT_SET:
+      errorListener_->addError(
+          "Type not specified in literal: " + literal.ShortDebugString());
+      return std::string("UNSPECIFIED_LITERAL_TYPE");
+  }
+  if (literal.nullable()) {
+    text << "?";
+  }
+  return text.str();
+}
+
+std::any PlanPrinterVisitor::visitFieldReference(
+    const ::substrait::proto::Expression::FieldReference& ref) {
+  // TODO -- Move this logic into visitDirectReference and visitMaskedReference.
+  switch (ref.reference_type_case()) {
+    case ::substrait::proto::Expression::FieldReference::kDirectReference:
+      return lookupFieldReference(
+          ref.direct_reference().struct_field().field());
+    case ::substrait::proto::Expression::FieldReference::kMaskedReference:
+      errorListener_->addError(
+          "Masked reference not yet supported: " + ref.ShortDebugString());
+      return "MASKED_REF_NOT_SUPPORTED";
+    case ::substrait::proto::Expression::FieldReference::REFERENCE_TYPE_NOT_SET:
+      errorListener_->addError("Reference type missing from field reference.");
+      return "";
+  }
+  errorListener_->addError(
+      "Field reference type not yet supported: " + ref.ShortDebugString());
+  return "FIELD_REF_TYPE_NOT_SUPPORTED";
+}
+
+std::any PlanPrinterVisitor::visitScalarFunction(
+    const ::substrait::proto::Expression::ScalarFunction& function) {
+  std::stringstream text;
+  text << lookupFunctionReference(function.function_reference()) << "(";
+  // TODO -- Eventually handle options.
+  bool hasPreviousText = false;
+  for (const auto& arg : function.arguments()) {
+    if (hasPreviousText) {
+      text << ", ";
+    }
+    switch (arg.arg_type_case()) {
+      case ::substrait::proto::FunctionArgument::kEnum:
+        errorListener_->addError(
+            "Enum arguments not yet supported in scalar functions: " +
+            arg.ShortDebugString());
+        text << "ENUM_NOT_SUPPORTED";
+        break;
+      case ::substrait::proto::FunctionArgument::kType:
+        text << ANY_CAST(std::string, visitType(arg.type()));
+        break;
+      case ::substrait::proto::FunctionArgument::kValue:
+        text << ANY_CAST(std::string, visitExpression(arg.value()));
+        break;
+      case ::substrait::proto::FunctionArgument::ARG_TYPE_NOT_SET:
+        errorListener_->addError("Argument type missing the type field.");
+        text << "SCALAR_FUNCTION_ARGUMENT_TYPE_MISSING";
+        break;
+    }
+    hasPreviousText = true;
+  }
+  for (const auto& arg : function.args()) {
+    if (hasPreviousText) {
+      text << ", ";
+    }
+    text << ANY_CAST(std::string, visitExpression(arg));
+    hasPreviousText = true;
+  }
+  // TODO -- Determine if the output type can be automatically determined.
+  // text << "->" << visitType(function.output_type());
+
+  if (!hasPreviousText) {
+    errorListener_->addError(
+        "Function encountered without any arguments: " +
+        function.ShortDebugString());
+  }
+  text << ")";
+  return text.str();
+}
+
+std::any PlanPrinterVisitor::visitWindowFunction(
+    const ::substrait::proto::Expression::WindowFunction& function) {
+  errorListener_->addError(
+      "Window functions are not yet supported: " + function.ShortDebugString());
+  return std::string("WINDOWFUNC_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitIfThen(
+    const ::substrait::proto::Expression::IfThen& ifthen) {
+  errorListener_->addError(
+      "If then expressions are not yet supported: " +
+      ifthen.ShortDebugString());
+  return std::string("IFTHEN_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitSwitchExpression(
+    const ::substrait::proto::Expression::SwitchExpression& expression) {
+  errorListener_->addError(
+      "Switch expressions are not yet supported: " +
+      expression.ShortDebugString());
+  return std::string("SWITCH_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitSingularOrList(
+    const ::substrait::proto::Expression::SingularOrList& expression) {
+  errorListener_->addError(
+      "Singular or list expressions are not yet supported: " +
+      expression.ShortDebugString());
+  return std::string("SINGORLIST_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitMultiOrList(
+    const ::substrait::proto::Expression::MultiOrList& expression) {
+  errorListener_->addError(
+      "Multiple or list expressions are not yet supported: " +
+      expression.ShortDebugString());
+  return std::string("MULTIORLIST_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitCast(
+    const ::substrait::proto::Expression::Cast& cast) {
+  std::stringstream text;
+  text << ANY_CAST(std::string, visitExpression(cast.input()));
+  text << " AS " << ANY_CAST(std::string, visitType(cast.type()));
+  // TODO -- Handle case.failure_behavior().
+  return text.str();
+}
+
+std::any PlanPrinterVisitor::visitSubquery(
+    const ::substrait::proto::Expression_Subquery& query) {
+  errorListener_->addError(
+      "Subquery expressions are not yet supported: " +
+      query.ShortDebugString());
+  return std::string("SUBQUERY_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitNested(
+    const ::substrait::proto::Expression_Nested& structure) {
+  errorListener_->addError(
+      "Nested expressions are not yet supported: " +
+      structure.ShortDebugString());
+  return std::string("NESTED_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitEnum(
+    const ::substrait::proto::Expression_Enum& value) {
+  errorListener_->addError(
+      "Enum expressions are not yet supported: " + value.ShortDebugString());
+  return std::string("ENUM_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitStructSelect(
+    const ::substrait::proto::Expression_MaskExpression_StructSelect&
+        structure) {
+  errorListener_->addError(
+      "Struct selects are not yet supported: " + structure.ShortDebugString());
+  return std::string("STRUCTSELECT_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitListSelect(
+    const ::substrait::proto::Expression_MaskExpression_ListSelect& select) {
+  errorListener_->addError(
+      "List selects are not yet supported: " + select.ShortDebugString());
+  return std::string("LISTSELECT_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitListSelectItem(
+    const ::substrait::proto::
+        Expression_MaskExpression_ListSelect_ListSelectItem& item) {
+  errorListener_->addError(
+      "List select items are not yet supported: " + item.ShortDebugString());
+  return std::string("LISTSELECTITEM_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitMapSelect(
+    const ::substrait::proto::Expression_MaskExpression_MapSelect& select) {
+  errorListener_->addError(
+      "Map selects are not yet supported: " + select.ShortDebugString());
+  return std::string("MAPSELECT_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitExpressionLiteralStruct(
+    const ::substrait::proto::Expression_Literal_Struct& structure) {
+  errorListener_->addError(
+      "Expression literals are not yet supported: " +
+      structure.ShortDebugString());
+  return std::string("EXPRLIT_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitFileOrFiles(
+    const ::substrait::proto::ReadRel_LocalFiles_FileOrFiles& structure) {
+  errorListener_->addError(
+      "Local file or files is not yet supported: " +
+      structure.ShortDebugString());
+  return std::string("FORF_NOT_YET_IMPLEMENTED");
+}
+
+std::any PlanPrinterVisitor::visitAggregateFunction(
+    const ::substrait::proto::AggregateFunction& function) {
+  std::stringstream text;
+  text << lookupFunctionReference(function.function_reference()) << "(";
+  bool hasPreviousText = false;
+  for (const auto& arg : function.arguments()) {
+    if (hasPreviousText) {
+      text << ", ";
+    }
+    switch (arg.arg_type_case()) {
+      case ::substrait::proto::FunctionArgument::kEnum:
+        text << "ENUM_NOT_SUPPORTED";
+        break;
+      case ::substrait::proto::FunctionArgument::kType:
+        text << ANY_CAST(std::string, visitType(arg.type()));
+        break;
+      case ::substrait::proto::FunctionArgument::kValue:
+        text << ANY_CAST(std::string, visitExpression(arg.value()));
+        break;
+      case ::substrait::proto::FunctionArgument::ARG_TYPE_NOT_SET:
+      default:
+        text << "UNKNOWN_AGGREGATE_FUNCTION_ARGUMENT_TYPE";
+        break;
+    }
+    hasPreviousText = true;
+  }
+  for (const auto& arg : function.args()) {
+    if (hasPreviousText) {
+      text << ", ";
+    }
+    text << ANY_CAST(std::string, visitExpression(arg));
+    hasPreviousText = true;
+  }
+  text << ")";
+  for (const auto& option : function.options()) {
+    text << "#" << option.name();
+    for (const auto& pref : option.preference()) {
+      text << ";" << pref;
+    }
+  }
+  text << "->" << ANY_CAST(std::string, visitType(function.output_type()));
+  // TODO -- Emit the requested sort behavior here.
+  text << "@" << ::substrait::proto::AggregationPhase_Name(function.phase());
+  return text.str();
+}
+
+std::any PlanPrinterVisitor::visitReferenceSegment(
+    const ::substrait::proto::Expression_ReferenceSegment& segment) {
+  errorListener_->addError(
+      "Reference segments are not yet supported: " +
+      segment.ShortDebugString());
+  return std::string("REFSEG_NOT_YET_IMPLEMENTED");
 }
 
 std::any PlanPrinterVisitor::visitMaskExpression(
     const ::substrait::proto::Expression::MaskExpression& expression) {
+  errorListener_->addError(
+      "Mask expressions are not yet supported: " +
+      expression.ShortDebugString());
   return std::string("MASKEXPR-NOT-YET-IMPLEMENTED");
 }
 
 std::any PlanPrinterVisitor::visitReadRelation(
     const ::substrait::proto::ReadRel& relation) {
   std::stringstream text;
+
+  ::google::protobuf::Message* msg;
+  switch (relation.read_type_case()) {
+    case ::substrait::proto::ReadRel::ReadTypeCase::kVirtualTable:
+      msg = (google::protobuf::Message*)&relation.virtual_table();
+      break;
+    case ::substrait::proto::ReadRel::ReadTypeCase::kLocalFiles:
+      msg = (::google::protobuf::Message*)&relation.local_files();
+      break;
+    case ::substrait::proto::ReadRel::ReadTypeCase::kNamedTable:
+      msg = (::google::protobuf::Message*)&relation.named_table();
+      break;
+    case ::substrait::proto::ReadRel::ReadTypeCase::kExtensionTable:
+      msg = (::google::protobuf::Message*)&relation.extension_table();
+      break;
+    case ::substrait::proto::ReadRel::READ_TYPE_NOT_SET:
+      return "";
+  }
+  const auto& symbol =
+      symbolTable_->lookupSymbolByLocation(PROTO_LOCATION(*msg));
+  if (symbol != SymbolInfo::kUnknown) {
+    text << "  source " << symbol.name << ";\n";
+  }
+
   if (relation.has_base_schema()) {
-    const auto& symbol = symbolTable_->lookupSymbolByLocation(
-        Location((google::protobuf::Message*)&relation));
-    if (symbol != SymbolTable::kUnknownSymbol) {
-      text << "  base_schema " << symbol.name << ";\n";
+    const auto& schemaSymbol = symbolTable_->lookupSymbolByLocation(
+        PROTO_LOCATION(relation.base_schema()));
+    if (schemaSymbol != SymbolInfo::kUnknown) {
+      text << "  base_schema " << schemaSymbol.name << ";\n";
     }
   }
   if (relation.has_filter()) {
@@ -164,16 +697,11 @@ std::any PlanPrinterVisitor::visitSortRelation(
         }
         break;
       case ::substrait::proto::SortField::kComparisonFunctionReference: {
-        auto field = symbolTable_->nthSymbolByType(
-            sort.comparison_function_reference(), SymbolType::kFunction);
-        if (field == SymbolTable::kUnknownSymbol) {
-          return field.name;
-        } else {
-          return "functionref#" +
-              std::to_string(sort.comparison_function_reference());
-        }
+        return lookupFunctionReference(sort.comparison_function_reference());
       }
       case ::substrait::proto::SortField::SORT_KIND_NOT_SET:
+        errorListener_->addError(
+            "Required sort kind missing from sort relation sort.");
         break;
     }
     text << ";\n";

--- a/src/substrait/textplan/converter/PlanPrinterVisitor.cpp
+++ b/src/substrait/textplan/converter/PlanPrinterVisitor.cpp
@@ -36,11 +36,6 @@ std::string PlanPrinterVisitor::printRelation(
   text << ::substrait::proto::relTypeCaseName(relation->rel_type_case())
        << " relation " << symbol.name << " {\n";
 
-#if 0
-  if (symbol != SymbolTable::kUnknownSymbol) {
-    text << "  source " << symbol.name << ";\n";
-  }
-#endif
   auto result = this->visitRelation(*relation);
   if (result.type() != typeid(std::string)) {
     errorListener_->addError(

--- a/src/substrait/textplan/converter/PlanPrinterVisitor.h
+++ b/src/substrait/textplan/converter/PlanPrinterVisitor.h
@@ -28,15 +28,64 @@ class PlanPrinterVisitor : public BasePlanProtoVisitor {
     return errorListener_;
   };
 
-  std::string printRelation(
-      const std::string& symbolName,
-      const ::substrait::proto::Rel* relation);
+  std::string printRelation(const ::substrait::proto::Rel* relation);
 
  private:
+  std::string lookupFieldReference(uint32_t field_reference);
+  std::string lookupFunctionReference(uint32_t function_reference);
+
+  std::any visitSelect(
+      const ::substrait::proto::Expression_MaskExpression_Select& select)
+      override;
+  std::any visitType(const ::substrait::proto::Type& type) override;
+  std::any visitStruct(
+      const ::substrait::proto::Type_Struct& structure) override;
+  std::any visitLiteral(
+      const ::substrait::proto::Expression::Literal& literal) override;
+  std::any visitFieldReference(
+      const ::substrait::proto::Expression::FieldReference& ref) override;
+  std::any visitScalarFunction(
+      const ::substrait::proto::Expression::ScalarFunction& function) override;
+  std::any visitWindowFunction(
+      const ::substrait::proto::Expression::WindowFunction& function) override;
+  std::any visitIfThen(
+      const ::substrait::proto::Expression::IfThen& ifthen) override;
+  std::any visitSwitchExpression(
+      const ::substrait::proto::Expression::SwitchExpression& expression)
+      override;
+  std::any visitSingularOrList(
+      const ::substrait::proto::Expression::SingularOrList& expression)
+      override;
+  std::any visitMultiOrList(
+      const ::substrait::proto::Expression::MultiOrList& expression) override;
+  std::any visitCast(const ::substrait::proto::Expression::Cast& cast) override;
+  std::any visitSubquery(
+      const ::substrait::proto::Expression_Subquery& query) override;
+  std::any visitNested(
+      const ::substrait::proto::Expression_Nested& structure) override;
+  std::any visitEnum(const ::substrait::proto::Expression_Enum& value) override;
+  std::any visitStructSelect(
+      const ::substrait::proto::Expression_MaskExpression_StructSelect&
+          structure) override;
+  std::any visitListSelect(
+      const ::substrait::proto::Expression_MaskExpression_ListSelect& select)
+      override;
+  std::any visitListSelectItem(
+      const ::substrait::proto::
+          Expression_MaskExpression_ListSelect_ListSelectItem& item) override;
+  std::any visitMapSelect(
+      const ::substrait::proto::Expression_MaskExpression_MapSelect& select)
+      override;
+  std::any visitExpressionLiteralStruct(
+      const ::substrait::proto::Expression_Literal_Struct& structure) override;
+  std::any visitFileOrFiles(
+      const ::substrait::proto::ReadRel_LocalFiles_FileOrFiles& structure)
+      override;
+  std::any visitReferenceSegment(
+      const ::substrait::proto::Expression_ReferenceSegment& segment) override;
+
   std::any visitAggregateFunction(
       const ::substrait::proto::AggregateFunction& function) override;
-  std::any visitExpression(
-      const ::substrait::proto::Expression& expression) override;
   std::any visitMaskExpression(
       const ::substrait::proto::Expression::MaskExpression& expression)
       override;

--- a/src/substrait/textplan/converter/Tool.cpp
+++ b/src/substrait/textplan/converter/Tool.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
     glob(argv[currArg], GLOB_TILDE, nullptr, &globResult);
     for (size_t i = 0; i < globResult.gl_pathc; i++) {
       printf("===== %s =====\n", globResult.gl_pathv[i]);
-      io::substrait::textplan::convertJSONToText(globResult.gl_pathv[i]);
+      io::substrait::textplan::convertJsonToText(globResult.gl_pathv[i]);
     }
   }
 

--- a/src/substrait/textplan/converter/Tool.cpp
+++ b/src/substrait/textplan/converter/Tool.cpp
@@ -1,7 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <getopt.h>
+#ifndef _WIN32
 #include <glob.h>
+#endif
 
 #include <iostream>
 
@@ -37,23 +38,18 @@ void convertJsonToText(const char* filename) {
 } // namespace io::substrait::textplan
 
 int main(int argc, char* argv[]) {
-  while (true) {
-    int optionIndex = 0;
-    static struct option longOptions[] = {{nullptr, 0, nullptr, 0}};
-
-    int c = getopt_long(argc, argv, "", longOptions, &optionIndex);
-    if (c == -1) {
-      break;
-    }
-  }
-
-  if (optind >= argc) {
+  if (argc <= 1) {
     printf("Usage:  planconverter <file1> <file2> ...\n");
     return EXIT_FAILURE;
   }
 
-  int currArg = optind;
-  for (; currArg < argc; currArg++) {
+#ifdef _WIN32
+  for (int currArg = 1; currArg < argc; currArg++) {
+    printf("===== %s =====\n", argv[currArg]);
+    io::substrait::textplan::convertJsonToText(argv[currArg]);
+  }
+#else
+  for (int currArg = 1; currArg < argc; currArg++) {
     glob_t globResult;
     glob(argv[currArg], GLOB_TILDE, nullptr, &globResult);
     for (size_t i = 0; i < globResult.gl_pathc; i++) {
@@ -61,6 +57,7 @@ int main(int argc, char* argv[]) {
       io::substrait::textplan::convertJsonToText(globResult.gl_pathv[i]);
     }
   }
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/src/substrait/textplan/tests/CMakeLists.txt
+++ b/src/substrait/textplan/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_test_case(
   SymbolTableTest.cpp
   EXTRA_LINK_LIBS
   symbol_table
+  substrait_common
   substrait_proto
   fmt::fmt-header-only
   gmock

--- a/src/substrait/textplan/tests/ParseResultMatchers.cpp
+++ b/src/substrait/textplan/tests/ParseResultMatchers.cpp
@@ -250,7 +250,7 @@ class HasSymbolsWithTypesMatcher {
       if (hasPreviousOutput) {
         *os << ", ";
       }
-      *os << SymbolTypeName(type);
+      *os << symbolTypeName(type);
       hasPreviousOutput = true;
     }
   }

--- a/src/substrait/textplan/tests/ParseResultMatchers.cpp
+++ b/src/substrait/textplan/tests/ParseResultMatchers.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 
@@ -62,6 +63,44 @@ bool stringEqSquashingWhitespace(
     } while (atHave != have.end() && isspace(*atHave));
   }
   return atHave == have.end() && atExpected == expected.end();
+}
+
+std::vector<std::string> symbolNamesWithTypes(
+    const std::vector<std::shared_ptr<SymbolInfo>>& symbols,
+    const std::set<SymbolType>& types) {
+  std::vector<std::string> names;
+  for (const auto& symbol : symbols) {
+    if (types.find(symbol->type) != types.end()) {
+      names.push_back(symbol->name);
+    }
+  }
+  return names;
+}
+
+std::vector<std::string> orderedSetDifference(
+    const std::vector<std::string>& haystack,
+    const std::vector<std::string>& source) {
+  std::vector<std::string> found(haystack.size());
+  std::vector<std::string> sortedHaystack = haystack;
+  std::vector<std::string> sortedSource = source;
+  std::sort(sortedHaystack.begin(), sortedHaystack.end());
+  std::sort(sortedSource.begin(), sortedSource.end());
+  auto end = std::set_difference(
+      sortedHaystack.begin(),
+      sortedHaystack.end(),
+      sortedSource.begin(),
+      sortedSource.end(),
+      found.begin());
+  found.resize(end - found.begin());
+  std::set<std::string> items;
+  items.insert(found.begin(), found.end());
+  std::vector<std::string> result;
+  for (const auto& item : haystack) {
+    if (items.find(item) != items.end()) {
+      result.push_back(item);
+    }
+  }
+  return result;
 }
 
 } // namespace
@@ -190,6 +229,91 @@ class WhenSerializedMatcher {
 ::testing::Matcher<const ParseResult&> WhenSerialized( // NOLINT
     ::testing::Matcher<const std::string&> stringMatcher) {
   return WhenSerializedMatcher(std::move(stringMatcher));
+}
+
+class HasSymbolsWithTypesMatcher {
+ public:
+  using is_gtest_matcher = void;
+
+  HasSymbolsWithTypesMatcher(
+      std::vector<std::string> expected_symbols,
+      std::vector<SymbolType> interesting_types)
+      : expectedSymbols_(std::move(expected_symbols)) {
+    interestingTypes_.insert(
+        interesting_types.begin(), interesting_types.end());
+  }
+
+  void DescribeTypes(std::ostream* os) const { // NOLINT
+    *os << " of types ";
+    bool hasPreviousOutput = false;
+    for (const auto& type : interestingTypes_) {
+      if (hasPreviousOutput) {
+        *os << ", ";
+      }
+      *os << SymbolTypeName(type);
+      hasPreviousOutput = true;
+    }
+  }
+
+  bool MatchAndExplain( // NOLINT
+      const ParseResult& result,
+      std::ostream* listener) const {
+    auto actualSymbols = symbolNamesWithTypes(
+        result.getSymbolTable().getSymbols(), interestingTypes_);
+    if (listener != nullptr) {
+      std::vector<std::string> extraSymbols =
+          orderedSetDifference(actualSymbols, expectedSymbols_);
+      if (!extraSymbols.empty()) {
+        *listener << std::endl << "          with extra symbols";
+        DescribeTypes(listener);
+        *listener << ": ";
+        for (const auto& symbol : extraSymbols) {
+          *listener << " \"" << symbol << "\"";
+        }
+      }
+
+      std::vector<std::string> missingSymbols =
+          orderedSetDifference(expectedSymbols_, actualSymbols);
+      if (!missingSymbols.empty()) {
+        if (!extraSymbols.empty()) {
+          *listener << ", and missing symbols";
+          DescribeTypes(listener);
+          *listener << ": ";
+        } else {
+          *listener << " with missing symbols";
+          DescribeTypes(listener);
+          *listener << ": ";
+        }
+        for (const auto& symbol : missingSymbols) {
+          *listener << " \"" << symbol << "\"";
+        }
+      }
+    }
+    return actualSymbols == expectedSymbols_;
+  }
+
+  void DescribeTo(std::ostream* os) const { // NOLINT
+    *os << "has exactly these symbols";
+    DescribeTypes(os);
+    *os << ": " << ::testing::PrintToString(expectedSymbols_);
+  }
+
+  void DescribeNegationTo(std::ostream* os) const { // NOLINT
+    *os << "does not have exactly these symbols";
+    DescribeTypes(os);
+    *os << ": " << ::testing::PrintToString(expectedSymbols_);
+  }
+
+ private:
+  const std::vector<std::string> expectedSymbols_;
+  std::set<SymbolType> interestingTypes_;
+};
+
+::testing::Matcher<const ParseResult&> HasSymbolsWithTypes(
+    std::vector<std::string> expected_symbols,
+    std::vector<SymbolType> interesting_types) {
+  return HasSymbolsWithTypesMatcher(
+      std::move(expected_symbols), std::move(interesting_types));
 }
 
 class HasErrorsMatcher {

--- a/src/substrait/textplan/tests/ParseResultMatchers.h
+++ b/src/substrait/textplan/tests/ParseResultMatchers.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -13,6 +16,11 @@ namespace io::substrait::textplan {
 
 [[maybe_unused]] ::testing::Matcher<const ParseResult&> HasSymbols( // NOLINT
     std::vector<std::string> expectedSymbols);
+
+[[maybe_unused]] ::testing::Matcher<const ParseResult&>
+HasSymbolsWithTypes( // NOLINT
+    std::vector<std::string> expectedSymbols,
+    std::vector<SymbolType> interestingTypes);
 
 [[maybe_unused]] ::testing::Matcher<const ParseResult&>
 WhenSerialized( // NOLINT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+set(ABSL_PROPAGATE_CXX_STD ON)
+add_subdirectory(abseil-cpp)
+
 add_subdirectory(fmt)
 add_subdirectory(googletest)
 


### PR DESCRIPTION
* Adds support for functions
* Adds support for most literal types (including Decimal)
* Quality improvements
   * Adds a new matcher that allows only symbols of a particular type to be matched
   * Added PROTO_LOCATION macro to make specifying locations more convenient.
   * Upgraded the converter tool to accept globs (only useful for testing as shells already expand globs).
   * Many error messages are now returned to the ParseResult instead of being left in text for a human to detect.