### PR TITLE
feat(lint): Add files for clang tidy and license check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+Checks: "*, \
+  -abseil-*, \
+  -cert-env33-c, \
+  -cert-err58-cpp, \
+  -clang-diagnostic-padded, \
+  -clang-analyzer-deadcode.DeadStores, \
+  -cppcoreguidelines-avoid-magic-numbers, \
+  -cppcoreguidelines-pro-bounds-constant-array-index, \
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic, \
+  -cppcoreguidelines-pro-type-reinterpret-cast, \
+  -cppcoreguidelines-no-malloc, \
+  -cppcoreguidelines-owning-memory, \
+  -cppcoreguidelines-macro-usage, \
+  -cppcoreguidelines-pro-type-vararg, \
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay, \
+  -fuchsia-overloaded-operator, \
+  -fuchsia-default-arguments, \  
+  -fuchsia-multiple-inheritance, \
+  -fuchsia-default-arguments-calls, \
+  -fuchsia-trailing-return, \
+  -fuchsia-default-arguments-declarations, \
+  -fuchsia-statically-constructed-objects, \
+  -google-runtime-references, \
+  -google-runtime-int, \
+  -google-explicit-constructor, \
+  -hicpp-no-malloc, \
+  -hicpp-vararg, \
+  -hicpp-invalid-access-moved, \
+  -hicpp-no-array-decay, \
+  -hicpp-signed-bitwise, \
+  -llvm-header-guard, \
+  -modernize-use-trailing-return-type, \
+  -misc-definitions-in-headers, \
+  -misc-unused-alias-decls, \
+  -modernize-concat-nested-namespaces, \
+  -modernize-raw-string-literal, \
+  -readability-magic-numbers"
+HeaderFilterRegex: ""
+...

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,13 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Apache Software Foundation
+
+  paths-ignore:
+    - 'dist'
+    - 'licenses'
+    - '**/*.md'
+    - 'LICENSE'
+    - 'NOTICE'
+
+  comment: on-failure

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+
+# Run clang-tidy recursively and parallel on directory
+# Usage: run-clang-tidy sourcedir builddir excludedirs extensions
+# extensions and excludedirs are specified as comma-separated
+# string without dot, e.g. 'c,cpp'
+# e.g. run-clang-tidy . build test,other c,cpp file
+
+import os, sys, subprocess, multiprocessing
+manager = multiprocessing.Manager()
+failedfiles = manager.list()
+
+# Get absolute current path and remove trailing seperators
+currentdir = os.path.realpath(os.getcwd()).rstrip(os.sep)
+print("Arguments: " + str(sys.argv))
+# Get absolute source dir after removing leading and trailing seperators from input.
+sourcedir = currentdir + sys.argv[1].lstrip(os.sep).rstrip(os.sep)
+print("Source directory: " + sourcedir)
+builddir = sourcedir + os.sep + sys.argv[2].rstrip(os.sep)
+print("Build directory: " + builddir)
+# Split exclude dirs into a tuple
+excludedirs = tuple([(sourcedir + os.sep + s).rstrip(os.sep) for s in sys.argv[3].split(',')])
+# If the build directory is not the same as the source directory, exclude it
+if not sourcedir == builddir:
+    excludedirs = excludedirs + (builddir,)
+print("Exclude directories: " + str(excludedirs))
+# Split extensions into a tuple
+extensions = tuple([("." + s) for s in sys.argv[4].split(',')])
+print("Extensions: " + str(extensions))
+
+def runclangtidy(filepath):
+    print("Checking: " + filepath)
+    proc = subprocess.Popen("clang-tidy --quiet -p=" + builddir + " " + filepath, shell=True)
+    if proc.wait() != 0:
+        failedfiles.append(filepath)
+
+def collectfiles(dir, exclude, exts):
+    collectedfiles = []
+    for root, dirs, files in os.walk(dir):
+        for file in files:
+            filepath = root + os.sep + file
+            if (len(exclude) == 0 or not filepath.startswith(exclude)) and filepath.endswith(exts):
+                collectedfiles.append(filepath)
+    return collectedfiles
+
+# Define the pool AFTER the global variables and subprocess function because multiprocessing
+# has stricter requirements on member ordering
+# See: https://stackoverflow.com/questions/41385708/multiprocessing-example-giving-attributeerror
+pool = multiprocessing.Pool()
+pool.map(runclangtidy, collectfiles(sourcedir, excludedirs, extensions))
+pool.close()
+pool.join()
+if len(failedfiles) > 0:
+    print("Errors in " + len(failedfiles) + " files")
+    sys.exit(1)
+print("No errors found")
+sys.exit(0)

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -19,6 +19,7 @@ sudo --preserve-env apt install -y \
   ccache \
   ninja-build \
   checkinstall \
+  clang-tidy \
   git \
   wget \
   libprotobuf-dev \


### PR DESCRIPTION
This PR  should be the first PR of issue https://github.com/substrait-io/substrait-cpp/issues/15, and  then the second [PR](https://github.com/substrait-io/substrait-cpp/pull/30) will use this  for lint check.

- please see https://github.com/apache/skywalking-eyes for license check
- run-clang-tidy.py : a python script used to check cpp project with clang-tidy