### PR TITLE
GH-41: Disable warnings about usage of deprecated args

### DIFF
--- a/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
+++ b/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
@@ -10,6 +10,8 @@
 #include "substrait/proto/algebra.pb.h"
 #include "substrait/proto/plan.pb.h"
 
+// The visitor should try and be tolerant of older plans.  This
+// requires calling deprecated APIs.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma gcc diagnostic push

--- a/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
+++ b/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
@@ -10,6 +10,11 @@
 #include "substrait/proto/algebra.pb.h"
 #include "substrait/proto/plan.pb.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma gcc diagnostic push
+#pragma gcc diagnostic ignored "-Wdeprecated-declarations"
+
 namespace io::substrait::textplan {
 
 std::any BasePlanProtoVisitor::visitSubqueryScalar(
@@ -1083,3 +1088,6 @@ std::any BasePlanProtoVisitor::visitPlan(const ::substrait::proto::Plan& plan) {
 }
 
 } // namespace io::substrait::textplan
+
+#pragma clang diagnostic pop
+#pragma gcc diagnostic pop


### PR DESCRIPTION
The converter is tolerant of older plans so it needs to utilize the deprecated plan format to function properly.
