### PR TITLE
feat: join relation and proper function scoping

### DIFF
--- a/src/substrait/textplan/RelationData.h
+++ b/src/substrait/textplan/RelationData.h
@@ -4,6 +4,8 @@
 
 #include "substrait/proto/algebra.pb.h"
 
+namespace io::substrait::textplan {
+
 struct RelationData {
   RelationData(
       const ::substrait::proto::Rel* relation,
@@ -24,4 +26,10 @@ struct RelationData {
 
   // A list of pipelines that start with this node and continue onward.
   std::vector<const ::substrait::proto::Rel*> newPipelines;
+
+  // Column name for each field known to this relation (in field order).
+  // TODO -- Use symbols instead of column names here.
+  std::vector<std::string> fieldReferences;
 };
+
+} // namespace io::substrait::textplan

--- a/src/substrait/textplan/converter/InitialPlanProtoVisitor.h
+++ b/src/substrait/textplan/converter/InitialPlanProtoVisitor.h
@@ -5,6 +5,7 @@
 #include <any>
 
 #include "substrait/proto/plan.pb.h"
+#include "substrait/textplan/RelationData.h"
 #include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTable.h"
 #include "substrait/textplan/converter/BasePlanProtoVisitor.h"
@@ -55,6 +56,28 @@ class InitialPlanProtoVisitor : public BasePlanProtoVisitor {
 
   std::any visitNamedStruct(
       const ::substrait::proto::NamedStruct& named) override;
+
+  void updateLocalSchema(
+      const std::shared_ptr<RelationData>& relationData,
+      const ::substrait::proto::Rel& relation);
+
+  void addFieldsToRelation(
+      const std::shared_ptr<RelationData>& relationData,
+      const ::substrait::proto::Rel& relation);
+
+  void addFieldsToRelation(
+      const std::shared_ptr<RelationData>& relationData,
+      const ::substrait::proto::Rel& left,
+      const ::substrait::proto::Rel& right);
+
+  template <typename T>
+  void addFieldsToRelation(
+      const std::shared_ptr<RelationData>& relationData,
+      const T& relations) {
+    for (const auto& rel : relations) {
+      addFieldsToRelation(relationData, rel);
+    }
+  };
 
   std::shared_ptr<SymbolTable> symbolTable_;
   std::shared_ptr<SubstraitErrorListener> errorListener_;

--- a/src/substrait/textplan/converter/PlanPrinterVisitor.h
+++ b/src/substrait/textplan/converter/PlanPrinterVisitor.h
@@ -17,6 +17,7 @@ class PlanPrinterVisitor : public BasePlanProtoVisitor {
   explicit PlanPrinterVisitor(const SymbolTable& symbolTable) {
     symbolTable_ = std::make_shared<SymbolTable>(symbolTable);
     errorListener_ = std::make_shared<SubstraitErrorListener>();
+    currentScope_ = &SymbolInfo::kUnknown;
   };
 
   [[nodiscard]] std::shared_ptr<const SymbolTable> getSymbolTable() const {
@@ -90,6 +91,8 @@ class PlanPrinterVisitor : public BasePlanProtoVisitor {
       const ::substrait::proto::Expression::MaskExpression& expression)
       override;
 
+  std::any visitRelation(const ::substrait::proto::Rel& relation) override;
+
   std::any visitReadRelation(
       const ::substrait::proto::ReadRel& relation) override;
   std::any visitFilterRelation(
@@ -102,9 +105,12 @@ class PlanPrinterVisitor : public BasePlanProtoVisitor {
       const ::substrait::proto::SortRel& relation) override;
   std::any visitProjectRelation(
       const ::substrait::proto::ProjectRel& relation) override;
+  std::any visitJoinRelation(
+      const ::substrait::proto::JoinRel& relation) override;
 
   std::shared_ptr<SymbolTable> symbolTable_;
   std::shared_ptr<SubstraitErrorListener> errorListener_;
+  const SymbolInfo* currentScope_; /* not owned */
 };
 
 } // namespace io::substrait::textplan

--- a/src/substrait/textplan/converter/README.md
+++ b/src/substrait/textplan/converter/README.md
@@ -1,0 +1,9 @@
+# Using the Plan Converter Tool
+
+The plan converter takes any number of JSON encoded Substrait plan files and converts them into the Substrait Text Plan
+format.
+
+## Usage:
+```
+planconverter <filename> ...
+```


### PR DESCRIPTION
* Implemented printing of the join relation.
* Now collects the schema for each relation in RelationData.
* Updated field references to be scoped as documented in the Substrait main repo.
* Added simple readme to explain how to use the plan converter tool.