### PR TITLE
refactor:  Separate type signature conversion into its own module

### DIFF
--- a/src/substrait/textplan/CMakeLists.txt
+++ b/src/substrait/textplan/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(
   SymbolTable.h
   SymbolTablePrinter.cpp
   SymbolTablePrinter.h
+  TypeConversion.cpp
+  TypeConversion.h
   Any.h
   RelationData.h)
 
@@ -17,7 +19,7 @@ add_library(error_listener SubstraitErrorListener.cpp SubstraitErrorListener.h)
 
 add_library(parse_result ParseResult.cpp ParseResult.h)
 
-add_dependencies(symbol_table substrait_proto substrait_common
+add_dependencies(symbol_table substrait_proto substrait_common substrait_type
                  fmt::fmt-header-only)
 
 target_link_libraries(symbol_table fmt::fmt-header-only)

--- a/src/substrait/textplan/SymbolTablePrinter.cpp
+++ b/src/substrait/textplan/SymbolTablePrinter.cpp
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include "SymbolTablePrinter.h"
+#include "substrait/textplan/SymbolTablePrinter.h"
 
 #include <set>
 #include <sstream>
@@ -11,6 +11,7 @@
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/RelationData.h"
 #include "substrait/textplan/SymbolTable.h"
+#include "substrait/textplan/TypeConversion.h"
 #include "substrait/textplan/converter/PlanPrinterVisitor.h"
 
 namespace io::substrait::textplan {
@@ -70,86 +71,6 @@ void localFileToText(
           std::to_string(item.file_format_case()) + "provided.");
   }
 }
-
-std::string typeToText(const ::substrait::proto::Type& type) {
-  switch (type.kind_case()) {
-    case ::substrait::proto::Type::kBool:
-      if (type.bool_().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "bool?";
-      }
-      return "bool";
-    case ::substrait::proto::Type::kI8:
-      if (type.i8().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i8?";
-      }
-      return "i8";
-    case ::substrait::proto::Type::kI16:
-      if (type.i16().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i16?";
-      }
-      return "i16";
-    case ::substrait::proto::Type::kI32:
-      if (type.i32().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i32?";
-      }
-      return "i32";
-    case ::substrait::proto::Type::kI64:
-      if (type.i64().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i64?";
-      }
-      return "i64";
-    case ::substrait::proto::Type::kFp32:
-      if (type.fp32().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "fp32?";
-      }
-      return "fp32";
-    case ::substrait::proto::Type::kFp64:
-      if (type.fp64().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "fp64?";
-      }
-      return "fp64";
-    case ::substrait::proto::Type::kString:
-      if (type.string().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "string?";
-      }
-      return "string";
-    case ::substrait::proto::Type::kDecimal:
-      if (type.string().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "decimal?";
-      }
-      return "decimal";
-    case ::substrait::proto::Type::kVarchar:
-      if (type.varchar().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "varchar?";
-      }
-      return "varchar";
-    case ::substrait::proto::Type::kFixedChar:
-      if (type.fixed_char().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "fixedchar?";
-      }
-      return "fixedchar";
-    case ::substrait::proto::Type::kDate:
-      if (type.date().nullability() ==
-          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "date?";
-      }
-      return "date";
-    case ::substrait::proto::Type::KIND_NOT_SET:
-    default:
-      return "UNSUPPORTED_TYPE";
-  }
-};
 
 std::string relationToText(
     const SymbolTable& symbolTable,

--- a/src/substrait/textplan/TypeConversion.cpp
+++ b/src/substrait/textplan/TypeConversion.cpp
@@ -6,127 +6,134 @@
 
 namespace io::substrait::textplan {
 
+namespace {
+
+std::string kNullSignature = "?";
+
+} // namespace
+
 // Converts a Type proto directly into its text signature form.
 std::string typeToText(const ::substrait::proto::Type& type) {
   switch (type.kind_case()) {
     case ::substrait::proto::Type::kBool:
       if (type.bool_().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "bool?";
+        return TypeTraits<TypeKind::kBool>::kSignature + kNullSignature;
       }
       return TypeTraits<TypeKind::kBool>::kSignature;
     case ::substrait::proto::Type::kI8:
       if (type.i8().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i8?";
+        return TypeTraits<TypeKind::kI8>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kI8>::kTypeString;
     case ::substrait::proto::Type::kI16:
       if (type.i16().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i16?";
+        return TypeTraits<TypeKind::kI16>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kI16>::kTypeString;
     case ::substrait::proto::Type::kI32:
       if (type.i32().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i32?";
+        return TypeTraits<TypeKind::kI32>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kI32>::kTypeString;
     case ::substrait::proto::Type::kI64:
       if (type.i64().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "i64?";
+        return TypeTraits<TypeKind::kI64>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kI64>::kTypeString;
     case ::substrait::proto::Type::kFp32:
       if (type.fp32().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "fp32?";
+        return TypeTraits<TypeKind::kFp32>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kFp32>::kTypeString;
     case ::substrait::proto::Type::kFp64:
       if (type.fp64().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "fp64?";
+        return TypeTraits<TypeKind::kFp64>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kFp64>::kTypeString;
     case ::substrait::proto::Type::kString:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "string?";
+        return TypeTraits<TypeKind::kString>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kString>::kTypeString;
     case ::substrait::proto::Type::kBinary:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "binary?";
+        return TypeTraits<TypeKind::kBinary>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kBinary>::kTypeString;
     case ::substrait::proto::Type::kTimestamp:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "timestamp?";
+        return TypeTraits<TypeKind::kTimestamp>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kTimestamp>::kTypeString;
     case ::substrait::proto::Type::kDate:
       if (type.date().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "date?";
+        return TypeTraits<TypeKind::kDate>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kDate>::kTypeString;
     case ::substrait::proto::Type::kTime:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "time?";
+        return TypeTraits<TypeKind::kTime>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kTime>::kTypeString;
     case ::substrait::proto::Type::kIntervalYear:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "interval_year?";
+        return TypeTraits<TypeKind::kIntervalYear>::kTypeString +
+            kNullSignature;
       }
       return TypeTraits<TypeKind::kIntervalYear>::kTypeString;
     case ::substrait::proto::Type::kIntervalDay:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "interval_day?";
+        return TypeTraits<TypeKind::kIntervalDay>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kIntervalDay>::kTypeString;
     case ::substrait::proto::Type::kTimestampTz:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "timestamp_tz?";
+        return TypeTraits<TypeKind::kTimestampTz>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kTimestampTz>::kTypeString;
     case ::substrait::proto::Type::kUuid:
       if (type.fixed_char().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "uuid?";
+        return TypeTraits<TypeKind::kUuid>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kUuid>::kTypeString;
     case ::substrait::proto::Type::kFixedChar:
       if (type.fixed_char().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "fixedchar?";
+        return TypeTraits<TypeKind::kFixedChar>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kFixedChar>::kTypeString;
     case ::substrait::proto::Type::kVarchar:
       if (type.varchar().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "varchar?";
+        return TypeTraits<TypeKind::kVarchar>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kVarchar>::kTypeString;
     case ::substrait::proto::Type::kFixedBinary:
       if (type.varchar().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "fixedbinary?";
+        return TypeTraits<TypeKind::kFixedBinary>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kFixedBinary>::kTypeString;
     case ::substrait::proto::Type::kDecimal:
       if (type.string().nullability() ==
           ::substrait::proto::Type::NULLABILITY_NULLABLE) {
-        return "decimal?";
+        return TypeTraits<TypeKind::kDecimal>::kTypeString + kNullSignature;
       }
       return TypeTraits<TypeKind::kDecimal>::kTypeString;
     case ::substrait::proto::Type::kStruct:

--- a/src/substrait/textplan/TypeConversion.cpp
+++ b/src/substrait/textplan/TypeConversion.cpp
@@ -1,0 +1,144 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "substrait/textplan/TypeConversion.h"
+
+#include "substrait/type/Type.h"
+
+namespace io::substrait::textplan {
+
+// Converts a Type proto directly into its text signature form.
+std::string typeToText(const ::substrait::proto::Type& type) {
+  switch (type.kind_case()) {
+    case ::substrait::proto::Type::kBool:
+      if (type.bool_().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "bool?";
+      }
+      return TypeTraits<TypeKind::kBool>::kSignature;
+    case ::substrait::proto::Type::kI8:
+      if (type.i8().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "i8?";
+      }
+      return TypeTraits<TypeKind::kI8>::kTypeString;
+    case ::substrait::proto::Type::kI16:
+      if (type.i16().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "i16?";
+      }
+      return TypeTraits<TypeKind::kI16>::kTypeString;
+    case ::substrait::proto::Type::kI32:
+      if (type.i32().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "i32?";
+      }
+      return TypeTraits<TypeKind::kI32>::kTypeString;
+    case ::substrait::proto::Type::kI64:
+      if (type.i64().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "i64?";
+      }
+      return TypeTraits<TypeKind::kI64>::kTypeString;
+    case ::substrait::proto::Type::kFp32:
+      if (type.fp32().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "fp32?";
+      }
+      return TypeTraits<TypeKind::kFp32>::kTypeString;
+    case ::substrait::proto::Type::kFp64:
+      if (type.fp64().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "fp64?";
+      }
+      return TypeTraits<TypeKind::kFp64>::kTypeString;
+    case ::substrait::proto::Type::kString:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "string?";
+      }
+      return TypeTraits<TypeKind::kString>::kTypeString;
+    case ::substrait::proto::Type::kBinary:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "binary?";
+      }
+      return TypeTraits<TypeKind::kBinary>::kTypeString;
+    case ::substrait::proto::Type::kTimestamp:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "timestamp?";
+      }
+      return TypeTraits<TypeKind::kTimestamp>::kTypeString;
+    case ::substrait::proto::Type::kDate:
+      if (type.date().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "date?";
+      }
+      return TypeTraits<TypeKind::kDate>::kTypeString;
+    case ::substrait::proto::Type::kTime:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "time?";
+      }
+      return TypeTraits<TypeKind::kTime>::kTypeString;
+    case ::substrait::proto::Type::kIntervalYear:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "interval_year?";
+      }
+      return TypeTraits<TypeKind::kIntervalYear>::kTypeString;
+    case ::substrait::proto::Type::kIntervalDay:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "interval_day?";
+      }
+      return TypeTraits<TypeKind::kIntervalDay>::kTypeString;
+    case ::substrait::proto::Type::kTimestampTz:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "timestamp_tz?";
+      }
+      return TypeTraits<TypeKind::kTimestampTz>::kTypeString;
+    case ::substrait::proto::Type::kUuid:
+      if (type.fixed_char().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "uuid?";
+      }
+      return TypeTraits<TypeKind::kUuid>::kTypeString;
+    case ::substrait::proto::Type::kFixedChar:
+      if (type.fixed_char().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "fixedchar?";
+      }
+      return TypeTraits<TypeKind::kFixedChar>::kTypeString;
+    case ::substrait::proto::Type::kVarchar:
+      if (type.varchar().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "varchar?";
+      }
+      return TypeTraits<TypeKind::kVarchar>::kTypeString;
+    case ::substrait::proto::Type::kFixedBinary:
+      if (type.varchar().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "fixedbinary?";
+      }
+      return TypeTraits<TypeKind::kFixedBinary>::kTypeString;
+    case ::substrait::proto::Type::kDecimal:
+      if (type.string().nullability() ==
+          ::substrait::proto::Type::NULLABILITY_NULLABLE) {
+        return "decimal?";
+      }
+      return TypeTraits<TypeKind::kDecimal>::kTypeString;
+    case ::substrait::proto::Type::kStruct:
+    case ::substrait::proto::Type::kList:
+    case ::substrait::proto::Type::kMap:
+      return "UNSUPPORTED_TYPE";
+    case ::substrait::proto::Type::kUserDefined:
+    case ::substrait::proto::Type::kUserDefinedTypeReference:
+    case ::substrait::proto::Type::KIND_NOT_SET:
+      break;
+  }
+  return "UNSUPPORTED_TYPE";
+};
+
+} // namespace io::substrait::textplan

--- a/src/substrait/textplan/TypeConversion.h
+++ b/src/substrait/textplan/TypeConversion.h
@@ -4,13 +4,10 @@
 
 #include <string>
 
-#include "substrait/textplan/SymbolTable.h"
+#include "substrait/proto/type.pb.h"
 
 namespace io::substrait::textplan {
 
-class SymbolTablePrinter {
- public:
-  static std::string outputToText(const SymbolTable& symbolTable);
-};
+std::string typeToText(const ::substrait::proto::Type& type);
 
 } // namespace io::substrait::textplan


### PR DESCRIPTION
Moves proto type (not the in-memory type Type) to type signature conversion routine into its own module.  The reverse conversion will join this routine in an upcoming PR.

