### PR TITLE
fix: Correct nullable handling behavior for complex types

### DIFF
--- a/src/substrait/type/Type.cpp
+++ b/src/substrait/type/Type.cpp
@@ -184,10 +184,9 @@ ParameterizedTypePtr ParameterizedType::decode(
 
   const auto& questionMaskPos = matchingType.find_last_of('?');
 
-  bool nullable = questionMaskPos != std::string::npos;
-
   const auto& leftAngleBracketPos = matchingType.find('<');
   if (leftAngleBracketPos == std::string::npos) {
+    bool nullable = matchingType.back() == '?';
     // deal with type and with a question mask like "i32?".
     const auto& baseType = nullable
         ? matchingType = matchingType.substr(0, questionMaskPos)
@@ -232,7 +231,9 @@ ParameterizedTypePtr ParameterizedType::decode(
           rawType, wildcard, placeholder);
     }
   } else {
-    const auto& rightAngleBracketPos = rawType.rfind('>');
+    bool nullable =
+        leftAngleBracketPos > 1 && matchingType[leftAngleBracketPos - 1] == '?';
+    const auto& rightAngleBracketPos = matchingType.rfind('>');
     const auto& baseTypePos = nullable
         ? std::min(leftAngleBracketPos, questionMaskPos)
         : leftAngleBracketPos;

--- a/src/substrait/type/Type.cpp
+++ b/src/substrait/type/Type.cpp
@@ -233,7 +233,7 @@ ParameterizedTypePtr ParameterizedType::decode(
   } else {
     bool nullable =
         leftAngleBracketPos > 1 && matchingType[leftAngleBracketPos - 1] == '?';
-    const auto& rightAngleBracketPos = matchingType.rfind('>');
+    const auto& rightAngleBracketPos = rawType.rfind('>');
     const auto& baseTypePos = nullable
         ? std::min(leftAngleBracketPos, questionMaskPos)
         : leftAngleBracketPos;

--- a/src/substrait/type/tests/TypeTest.cpp
+++ b/src/substrait/type/tests/TypeTest.cpp
@@ -206,6 +206,14 @@ TEST_F(TypeTest, decodeTest) {
         ASSERT_TRUE(typePtr->elementType()->isPlaceholder());
       });
 
+  testDecode<ParameterizedList>(
+      "list<string?>",
+      [](const std::shared_ptr<const ParameterizedList>& typePtr) {
+        ASSERT_FALSE(typePtr->nullable());
+        ASSERT_TRUE(typePtr->elementType()->nullable());
+        ASSERT_EQ(typePtr->signature(), "list<str>");
+      });
+
   testDecode<ParameterizedMap>(
       "map<string,i32>",
       [](const std::shared_ptr<const ParameterizedMap>& typePtr) {


### PR DESCRIPTION
Previously a question mark anywhere within a type string would make a type nullable.  This PR corrects that calculation.  