### PR TITLE
feat:  Add first mismatch to EqSquashingWhitespace googletest matcher

### DIFF
--- a/src/substrait/textplan/converter/PlanPrinterVisitor.cpp
+++ b/src/substrait/textplan/converter/PlanPrinterVisitor.cpp
@@ -364,9 +364,9 @@ std::any PlanPrinterVisitor::visitFieldReference(
 // The visitor should be tolerant of older plans.  This requires calling
 // deprecated APIs.
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecatted-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma gcc diagnostic push
-#pragma gcc diagnostic ignored "-Wdeprecatted-declarations"
+#pragma gcc diagnostic ignored "-Wdeprecated-declarations"
 
 std::any PlanPrinterVisitor::visitScalarFunction(
     const ::substrait::proto::Expression::ScalarFunction& function) {

--- a/src/substrait/textplan/tests/ParseResultMatchers.cpp
+++ b/src/substrait/textplan/tests/ParseResultMatchers.cpp
@@ -30,7 +30,8 @@ std::vector<std::string> symbolNames(
 
 bool stringEqSquashingWhitespace(
     const std::string& have,
-    const std::string& expected) {
+    const std::string& expected,
+    std::ostream* listener) {
   auto atHave = have.begin();
   auto atExpected = expected.begin();
   while (atHave != have.end() && atExpected != expected.end()) {
@@ -48,6 +49,14 @@ bool stringEqSquashingWhitespace(
       continue;
     }
     if (*atHave != *atExpected) {
+      if (listener) {
+        *listener << "first mismatch at character #"
+                  << std::to_string(atHave - have.begin()) << " |"
+                  << have.substr(atHave - have.begin(), 20) << "|"
+                  << " should be |"
+                  << expected.substr(atExpected - expected.begin(), 20) << "|"
+                  << std::endl;
+      }
       return false;
     }
     atHave++;
@@ -134,7 +143,7 @@ class HasSymbolsMatcher {
  public:
   using is_gtest_matcher = void;
 
-  explicit HasSymbolsMatcher(std::vector<std::string> expectedSymbols)
+  explicit HasSymbolsMatcher(const std::vector<std::string>& expectedSymbols)
       : expectedSymbols_(std::move(expectedSymbols)) {}
 
   bool MatchAndExplain(const ParseResult& result, std::ostream* listener)
@@ -193,7 +202,7 @@ class HasSymbolsMatcher {
 };
 
 ::testing::Matcher<const ParseResult&> HasSymbols(
-    std::vector<std::string> expectedSymbols) {
+    const std::vector<std::string>& expectedSymbols) {
   return HasSymbolsMatcher(std::move(expectedSymbols));
 }
 
@@ -237,8 +246,8 @@ class HasSymbolsWithTypesMatcher {
   using is_gtest_matcher = void;
 
   HasSymbolsWithTypesMatcher(
-      std::vector<std::string> expected_symbols,
-      std::vector<SymbolType> interesting_types)
+      const std::vector<std::string>& expected_symbols,
+      const std::vector<SymbolType>& interesting_types)
       : expectedSymbols_(std::move(expected_symbols)) {
     interestingTypes_.insert(
         interesting_types.begin(), interesting_types.end());
@@ -310,8 +319,8 @@ class HasSymbolsWithTypesMatcher {
 };
 
 ::testing::Matcher<const ParseResult&> HasSymbolsWithTypes(
-    std::vector<std::string> expected_symbols,
-    std::vector<SymbolType> interesting_types) {
+    const std::vector<std::string>& expected_symbols,
+    const std::vector<SymbolType>& interesting_types) {
   return HasSymbolsWithTypesMatcher(
       std::move(expected_symbols), std::move(interesting_types));
 }
@@ -320,7 +329,7 @@ class HasErrorsMatcher {
  public:
   using is_gtest_matcher = void;
 
-  explicit HasErrorsMatcher(std::vector<std::string> expectedErrors)
+  explicit HasErrorsMatcher(const std::vector<std::string>& expectedErrors)
       : expectedErrors_(std::move(expectedErrors)) {}
 
   bool MatchAndExplain(const ParseResult& result, std::ostream* /* listener */)
@@ -329,12 +338,12 @@ class HasErrorsMatcher {
   }
 
   void DescribeTo(std::ostream* os) const {
-    *os << "has exactly these symbols: "
+    *os << "has exactly these errors: "
         << ::testing::PrintToString(expectedErrors_);
   }
 
   void DescribeNegationTo(std::ostream* os) const {
-    *os << "does not have exactly these symbols: "
+    *os << "does not have exactly these errors: "
         << ::testing::PrintToString(expectedErrors_);
   }
 
@@ -343,7 +352,7 @@ class HasErrorsMatcher {
 };
 
 ::testing::Matcher<const ParseResult&> HasErrors(
-    std::vector<std::string> expectedErrors) {
+    const std::vector<std::string>& expectedErrors) {
   return HasErrorsMatcher(std::move(expectedErrors));
 }
 
@@ -351,12 +360,11 @@ class EqSquashingWhitespaceMatcher {
  public:
   using is_gtest_matcher = void;
 
-  explicit EqSquashingWhitespaceMatcher(std::string expectedString)
+  explicit EqSquashingWhitespaceMatcher(const std::string& expectedString)
       : expectedString_(std::move(expectedString)) {}
 
-  bool MatchAndExplain(const std::string& str, std::ostream* /* listener */)
-      const {
-    return stringEqSquashingWhitespace(str, expectedString_);
+  bool MatchAndExplain(const std::string& str, std::ostream* listener) const {
+    return stringEqSquashingWhitespace(str, expectedString_, listener);
   }
 
   void DescribeTo(std::ostream* os) const {
@@ -374,7 +382,7 @@ class EqSquashingWhitespaceMatcher {
 };
 
 ::testing::Matcher<const std::string&> EqSquashingWhitespace(
-    std::string expectedString) {
+    const std::string& expectedString) {
   return EqSquashingWhitespaceMatcher(std::move(expectedString));
 }
 

--- a/src/substrait/textplan/tests/ParseResultMatchers.h
+++ b/src/substrait/textplan/tests/ParseResultMatchers.h
@@ -17,22 +17,22 @@ namespace io::substrait::textplan {
 [[maybe_unused]] ::testing::Matcher<const ParseResult&> ParsesOk();
 
 [[maybe_unused]] ::testing::Matcher<const ParseResult&> HasSymbols(
-    std::vector<std::string> expectedSymbols);
+    const std::vector<std::string>& expectedSymbols);
 
 [[maybe_unused]] ::testing::Matcher<const ParseResult&> HasSymbolsWithTypes(
-    std::vector<std::string> expected_symbols,
-    std::vector<SymbolType> interesting_types);
+    const std::vector<std::string>& expected_symbols,
+    const std::vector<SymbolType>& interesting_types);
 
 [[maybe_unused]] ::testing::Matcher<const ParseResult&> WhenSerialized(
     ::testing::Matcher<const std::string&> stringMatcher);
 
 [[maybe_unused]] ::testing::Matcher<const ParseResult&> HasErrors(
-    std::vector<std::string> expectedErrors);
+    const std::vector<std::string>& expectedErrors);
 
 // Matches strings ignoring differences in kinds of whitespace (as long as they
 // are present) and ignoring trailing whitespace as well.
 [[maybe_unused]] ::testing::Matcher<const std::string&> EqSquashingWhitespace(
-    std::string expectedString);
+    const std::string& expectedString);
 
 // NOLINTEND(readability-identifier-naming)
 


### PR DESCRIPTION
Now emits the first mismatch between the two strings to aid in determining what went wrong.

This PR also updates the parameter passing style used.
