### PR TITLE
fix: detect when maps are missing keys and/or values

### DIFF
--- a/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
@@ -1223,6 +1223,11 @@ SubstraitPlanRelationVisitor::visitTimestampTz(
     }
     case TypeKind::kMap: {
       auto map = reinterpret_cast<const ParameterizedMap*>(&decodedType);
+      if (map->keyType() == nullptr || map->valueType() == nullptr) {
+        errorListener_->addError(
+            token, "Maps require both a key and a value type.");
+        break;
+      }
       *type.mutable_map()->mutable_key() = typeToProto(token, *map->keyType());
       *type.mutable_map()->mutable_value() =
           typeToProto(token, *map->valueType());

--- a/src/substrait/textplan/parser/grammar/SubstraitPlanParser.g4
+++ b/src/substrait/textplan/parser/grammar/SubstraitPlanParser.g4
@@ -89,7 +89,7 @@ literal_basic_type
 literal_complex_type
    : literal_basic_type
    | LIST QUESTIONMARK? LEFTANGLEBRACKET literal_complex_type? RIGHTANGLEBRACKET
-   | MAP QUESTIONMARK? LEFTANGLEBRACKET (literal_basic_type COMMA literal_complex_type)? RIGHTANGLEBRACKET
+   | MAP QUESTIONMARK? LEFTANGLEBRACKET literal_basic_type? COMMA? literal_complex_type? RIGHTANGLEBRACKET
    | STRUCT QUESTIONMARK? LEFTANGLEBRACKET literal_complex_type? (COMMA literal_complex_type)* RIGHTANGLEBRACKET
    ;
 

--- a/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
+++ b/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
@@ -628,7 +628,7 @@ std::vector<TestCase> getTestCases() {
             expression {}_list<string>?;
             expression {}_struct<a>;
             expression {}_struct<>;
-            //expression {}_map<>;  // TODO - Catch this behavior.
+            expression {}_map<>;
             expression {}_list<>;
             expression "unknown\escape"_string;
             expression {123_i8}_map<i8, bool>;
@@ -658,6 +658,8 @@ std::vector<TestCase> getTestCases() {
               "11:23 → Could not parse literal as decimal.",
               "13:26 → Unable to recognize requested type.",
               "14:26 → Unable to recognize requested type.",
+              "15:26 → Maps require both a key and a value type.",
+              "15:23 → Unsupported type 0.",
               "16:26 → Unable to recognize requested type.",
               "17:31 → Unknown slash escape sequence.",
               "18:23 → Map literals require pairs of values separated by colons.",

--- a/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
+++ b/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
@@ -629,6 +629,9 @@ std::vector<TestCase> getTestCases() {
             expression {}_struct<a>;
             expression {}_struct<>;
             expression {}_map<>;
+            expression {}_map<string>;
+            expression {}_map<,string>;
+            expression {}_map<,>;
             expression {}_list<>;
             expression "unknown\escape"_string;
             expression {123_i8}_map<i8, bool>;
@@ -660,10 +663,15 @@ std::vector<TestCase> getTestCases() {
               "14:26 → Unable to recognize requested type.",
               "15:26 → Maps require both a key and a value type.",
               "15:23 → Unsupported type 0.",
-              "16:26 → Unable to recognize requested type.",
-              "17:31 → Unknown slash escape sequence.",
-              "18:23 → Map literals require pairs of values separated by colons.",
-              "19:23 → Map literals require pairs of values separated by colons.",
+              "16:26 → Maps require both a key and a value type.",
+              "16:23 → Unsupported type 0.",
+              "17:26 → Unable to recognize requested type.",
+              "18:26 → Unable to recognize requested type.",
+              "18:26 → Unable to recognize requested type.",
+              "19:26 → Unable to recognize requested type.",
+              "20:31 → Unknown slash escape sequence.",
+              "21:23 → Map literals require pairs of values separated by colons.",
+              "22:23 → Map literals require pairs of values separated by colons.",
           }),
       },
       {


### PR DESCRIPTION
Now that the underlying type library doesn't segfault when given a map missing a key or value, properly detect such cases and return errors.