### PR TITLE
refactor:  upgrade multi-key sort

### DIFF
--- a/src/substrait/textplan/converter/ReferenceNormalizer.cpp
+++ b/src/substrait/textplan/converter/ReferenceNormalizer.cpp
@@ -20,9 +20,9 @@ bool compareExtensionFunctions(
         // extension.
         not decl.has_extension_function(),
         // Next sort by space.
-        decl.extension_function().extension_uri_reference(),
+        std::string_view{decl.extension_function().extension_uri_reference()},
         // Finally sort by name within a space.
-        decl.extension_function().name());
+        std::string_view{decl.extension_function().name()});
   };
 
   // Now let the default tuple compare do the rest of the work.

--- a/src/substrait/textplan/converter/ReferenceNormalizer.cpp
+++ b/src/substrait/textplan/converter/ReferenceNormalizer.cpp
@@ -20,7 +20,7 @@ bool compareExtensionFunctions(
         // extension.
         not decl.has_extension_function(),
         // Next sort by space.
-        std::string_view{decl.extension_function().extension_uri_reference()},
+        decl.extension_function().extension_uri_reference(),
         // Finally sort by name within a space.
         std::string_view{decl.extension_function().name()});
   };


### PR DESCRIPTION
As suggested by @bkietz this PR upgrades the sort routine to utilize tuple's built-in compare behavior.  This reduces the complexity of evaluating each set of four possibilities for each key manually.
