### PR TITLE
feat: switch datetime package to an external dependency

### DIFF
--- a/src/substrait/textplan/converter/CMakeLists.txt
+++ b/src/substrait/textplan/converter/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+include(../../../../third_party/datetime.cmake)
+
 set(TEXTPLAN_SRCS
     InitialPlanProtoVisitor.cpp
     InitialPlanProtoVisitor.h

--- a/src/substrait/textplan/parser/CMakeLists.txt
+++ b/src/substrait/textplan/parser/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+include(../../../../third_party/datetime.cmake)
+
 add_subdirectory(grammar)
 
 add_library(

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(NOT ${ABSL_INCLUDED_WITH_PROTOBUF})
-    set(ABSL_PROPAGATE_CXX_STD ON)
-    add_subdirectory(abseil-cpp)
+  set(ABSL_PROPAGATE_CXX_STD ON)
+  add_subdirectory(abseil-cpp)
 endif()
 
 include(datetime.cmake)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(NOT ${ABSL_INCLUDED_WITH_PROTOBUF})
-  set(ABSL_PROPAGATE_CXX_STD ON)
-  add_subdirectory(abseil-cpp)
+    set(ABSL_PROPAGATE_CXX_STD ON)
+    add_subdirectory(abseil-cpp)
 endif()
 
-set(BUILD_TZ_LIB ON)
-add_subdirectory(datetime)
+include(datetime.cmake)
 
 add_subdirectory(fmt)
 add_subdirectory(googletest)

--- a/third_party/datetime.cmake
+++ b/third_party/datetime.cmake
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+set (BUILD_TZ_LIB ON CACHE BOOL "timezone library is a dependency" FORCE)
+include(FetchContent)
+FetchContent_Declare(date_src
+        GIT_REPOSITORY https://github.com/HowardHinnant/date.git
+        GIT_TAG v3.0.1
+        )
+#if(NOT ${date_src_POPULATED})
+    FetchContent_MakeAvailable(date_src)
+#endif()

--- a/third_party/datetime.cmake
+++ b/third_party/datetime.cmake
@@ -8,6 +8,4 @@ FetchContent_Declare(date_src
         GIT_REPOSITORY https://github.com/HowardHinnant/date.git
         GIT_TAG v3.0.1
         )
-#if(NOT ${date_src_POPULATED})
-    FetchContent_MakeAvailable(date_src)
-#endif()
+FetchContent_MakeAvailable(date_src)


### PR DESCRIPTION
By switching to an external dependency controlled by a central file we can more cleanly reference date::date and date::tz.  We could do the same by "externally loading" a submodule but either way we end up downloading the datetime repo.
