### PR TITLE
fix: Set TEXTPLAN_SOURCE_DIR based on current dir in planloader test.

### DIFF
--- a/export/planloader/tests/CMakeLists.txt
+++ b/export/planloader/tests/CMakeLists.txt
@@ -15,10 +15,7 @@ add_test_case(
   gtest
   gtest_main)
 
-cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH TEXTPLAN_SOURCE_DIR)
-cmake_path(GET TEXTPLAN_SOURCE_DIR PARENT_PATH TEXTPLAN_SOURCE_DIR)
-cmake_path(GET TEXTPLAN_SOURCE_DIR PARENT_PATH TEXTPLAN_SOURCE_DIR)
-set(TEXTPLAN_SOURCE_DIR "${TEXTPLAN_SOURCE_DIR}/src/substrait/textplan")
+set(TEXTPLAN_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/substrait/textplan")
 
 add_custom_command(
   TARGET planloader_test

--- a/export/planloader/tests/CMakeLists.txt
+++ b/export/planloader/tests/CMakeLists.txt
@@ -15,7 +15,10 @@ add_test_case(
   gtest
   gtest_main)
 
-set(TEXTPLAN_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/substrait/textplan")
+cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH TEXTPLAN_SOURCE_DIR)
+cmake_path(GET TEXTPLAN_SOURCE_DIR PARENT_PATH TEXTPLAN_SOURCE_DIR)
+cmake_path(GET TEXTPLAN_SOURCE_DIR PARENT_PATH TEXTPLAN_SOURCE_DIR)
+set(TEXTPLAN_SOURCE_DIR "${TEXTPLAN_SOURCE_DIR}/src/substrait/textplan")
 
 add_custom_command(
   TARGET planloader_test

--- a/export/planloader/tests/CMakeLists.txt
+++ b/export/planloader/tests/CMakeLists.txt
@@ -15,7 +15,8 @@ add_test_case(
   gtest
   gtest_main)
 
-set(TEXTPLAN_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/substrait/textplan")
+set(TEXTPLAN_SOURCE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/substrait/textplan")
 
 add_custom_command(
   TARGET planloader_test


### PR DESCRIPTION
That variable was previously computed based on `CMAKE_SOURCE_DIR`, which is the wrong value if `substrait-cpp` is used as a dependency from a different top-level CMake project. The PR applies the pattern based on `CMAKE_CURRENT_SOURCE_DIR` used in other tests.