### PR TITLE
feat: Make main target installable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,5 +63,7 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
   enable_testing()
 endif()
 
+install(EXPORT SubstraitTargets DESTINATION lib/cmake/Substrait)
+
 add_subdirectory(src/substrait)
 add_subdirectory(export)

--- a/export/planloader/CMakeLists.txt
+++ b/export/planloader/CMakeLists.txt
@@ -7,8 +7,21 @@ target_link_libraries(planloader substrait_io)
 
 install(
   TARGETS planloader
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCDIR})
+          substrait_io
+          substrait_common
+          substrait_proto
+          substrait_textplan_converter
+          substrait_textplan_loader
+          substrait_base_proto_visitor
+          symbol_table
+          error_listener
+          substrait_type
+          substrait_expression
+          textplan_grammar
+  EXPORT SubstraitTargets)
+install(FILES ../../include/substrait/common/Io.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/common")
+install(EXPORT SubstraitTargets DESTINATION lib/cmake/Substrait)
 
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)

--- a/export/planloader/CMakeLists.txt
+++ b/export/planloader/CMakeLists.txt
@@ -5,24 +5,10 @@ add_library(planloader SHARED planloader.cpp)
 add_dependencies(planloader substrait_io)
 target_link_libraries(planloader substrait_io)
 
-install(
-  TARGETS planloader
-          substrait_io
-          substrait_common
-          substrait_proto
-          substrait_textplan_converter
-          substrait_textplan_loader
-          substrait_base_proto_visitor
-          symbol_table
-          error_listener
-          substrait_type
-          substrait_expression
-          textplan_grammar
-  EXPORT SubstraitTargets)
-install(FILES ../../include/substrait/common/Io.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/common")
-install(EXPORT SubstraitTargets DESTINATION lib/cmake/Substrait)
-
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
+
+install(TARGETS planloader EXPORT SubstraitTargets)
+
+install(EXPORT SubstraitTargets DESTINATION lib/cmake/Substrait)

--- a/export/planloader/CMakeLists.txt
+++ b/export/planloader/CMakeLists.txt
@@ -10,5 +10,3 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
 endif()
 
 install(TARGETS planloader EXPORT SubstraitTargets)
-
-install(EXPORT SubstraitTargets DESTINATION lib/cmake/Substrait)

--- a/src/substrait/CMakeLists.txt
+++ b/src/substrait/CMakeLists.txt
@@ -18,9 +18,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
 set(ADDITIONAL_CLEAN_FILES
     "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY};${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
-add_subdirectory(common)
 add_subdirectory(type)
 add_subdirectory(expression)
 add_subdirectory(function)
 add_subdirectory(proto)
 add_subdirectory(textplan)
+add_subdirectory(common)

--- a/src/substrait/CMakeLists.txt
+++ b/src/substrait/CMakeLists.txt
@@ -18,9 +18,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
 set(ADDITIONAL_CLEAN_FILES
     "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY};${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
+add_subdirectory(common)
 add_subdirectory(type)
 add_subdirectory(expression)
 add_subdirectory(function)
 add_subdirectory(proto)
 add_subdirectory(textplan)
-add_subdirectory(common)

--- a/src/substrait/common/CMakeLists.txt
+++ b/src/substrait/common/CMakeLists.txt
@@ -24,9 +24,23 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-install(TARGETS substrait_io LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(
+  TARGETS substrait_io
+          substrait_common
+          substrait_proto
+          substrait_textplan_converter
+          substrait_textplan_loader
+          substrait_base_proto_visitor
+          symbol_table
+          error_listener
+          substrait_type
+          substrait_expression
+          textplan_grammar
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  EXPORT SubstraitTargets)
 install(FILES ../../../include/substrait/common/Io.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/common")
+install(EXPORT SubstraitTargets DESTINATION lib/cmake/Substrait)
 
 add_executable(plantransformer PlanTransformerTool.cpp)
 

--- a/src/substrait/common/CMakeLists.txt
+++ b/src/substrait/common/CMakeLists.txt
@@ -24,24 +24,6 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-install(
-  TARGETS substrait_io
-          substrait_common
-          substrait_proto
-          substrait_textplan_converter
-          substrait_textplan_loader
-          substrait_base_proto_visitor
-          symbol_table
-          error_listener
-          substrait_type
-          substrait_expression
-          textplan_grammar
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  EXPORT SubstraitTargets)
-install(FILES ../../../include/substrait/common/Io.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/common")
-install(EXPORT SubstraitTargets DESTINATION lib/cmake/Substrait)
-
 add_executable(plantransformer PlanTransformerTool.cpp)
 
 target_link_libraries(plantransformer substrait_io)

--- a/src/substrait/common/CMakeLists.txt
+++ b/src/substrait/common/CMakeLists.txt
@@ -4,6 +4,9 @@ add_library(substrait_common Exceptions.cpp)
 target_link_libraries(substrait_common fmt::fmt-header-only)
 
 add_library(substrait_io STATIC Io.cpp)
+set_target_properties(
+  substrait_io PROPERTIES PUBLIC_HEADER ../../../include/substrait/common/Io.h)
+
 add_dependencies(
   substrait_io
   substrait_proto
@@ -27,3 +30,9 @@ endif()
 add_executable(plantransformer PlanTransformerTool.cpp)
 
 target_link_libraries(plantransformer substrait_io)
+
+install(
+  TARGETS substrait_common substrait_io
+  EXPORT SubstraitTargets
+  LIBRARY
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/common")

--- a/src/substrait/common/CMakeLists.txt
+++ b/src/substrait/common/CMakeLists.txt
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_library(substrait_common Exceptions.cpp)
+target_sources(
+  substrait_common PUBLIC FILE_SET HEADERS BASE_DIRS ../../../include/ FILES
+                          ../../../include/substrait/common/Exceptions.h)
 target_link_libraries(substrait_common fmt::fmt-header-only)
 
 add_library(substrait_io STATIC Io.cpp)
-set_target_properties(
-  substrait_io PROPERTIES PUBLIC_HEADER ../../../include/substrait/common/Io.h)
+target_sources(substrait_io PUBLIC FILE_SET HEADERS BASE_DIRS ../../../include/
+                                   FILES ../../../include/substrait/common/Io.h)
 
 add_dependencies(
   substrait_io
@@ -32,7 +35,6 @@ add_executable(plantransformer PlanTransformerTool.cpp)
 target_link_libraries(plantransformer substrait_io)
 
 install(
-  TARGETS substrait_common substrait_io
+  TARGETS substrait_common substrait_io plantransformer
   EXPORT SubstraitTargets
-  LIBRARY
-  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/common")
+  LIBRARY FILE_SET HEADERS)

--- a/src/substrait/expression/CMakeLists.txt
+++ b/src/substrait/expression/CMakeLists.txt
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_library(substrait_expression DecimalLiteral.cpp)
+target_sources(
+  substrait_expression
+  PUBLIC FILE_SET HEADERS BASE_DIRS ../../../include/ FILES
+         ../../../include/substrait/expression/DecimalLiteral.h)
 
 target_link_libraries(substrait_expression substrait_proto absl::numeric
                       absl::strings)
@@ -9,4 +13,7 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-install(TARGETS substrait_expression EXPORT SubstraitTargets)
+install(
+  TARGETS substrait_expression
+  EXPORT SubstraitTargets
+  FILE_SET HEADERS)

--- a/src/substrait/expression/CMakeLists.txt
+++ b/src/substrait/expression/CMakeLists.txt
@@ -8,3 +8,5 @@ target_link_libraries(substrait_expression substrait_proto absl::numeric
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
+
+install(TARGETS substrait_expression EXPORT SubstraitTargets)

--- a/src/substrait/function/CMakeLists.txt
+++ b/src/substrait/function/CMakeLists.txt
@@ -3,6 +3,17 @@
 set(FUNCTION_SRCS Function.cpp Extension.cpp FunctionLookup.cpp)
 
 add_library(substrait_function ${FUNCTION_SRCS})
+target_sources(
+  substrait_function
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ../../../include/
+         FILES
+         ../../../include/substrait/function/Extension.h
+         ../../../include/substrait/function/Function.h
+         ../../../include/substrait/function/FunctionLookup.h
+         ../../../include/substrait/function/FunctionSignature.h)
 
 target_link_libraries(substrait_function substrait_type yaml-cpp)
 
@@ -10,4 +21,7 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-install(TARGETS substrait_function EXPORT SubstraitTargets)
+install(
+  TARGETS substrait_function
+  EXPORT SubstraitTargets
+  FILE_SET HEADERS)

--- a/src/substrait/function/CMakeLists.txt
+++ b/src/substrait/function/CMakeLists.txt
@@ -9,3 +9,5 @@ target_link_libraries(substrait_function substrait_type yaml-cpp)
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
+
+install(TARGETS substrait_function EXPORT SubstraitTargets)

--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -79,7 +79,9 @@ endforeach()
 # Add the generated protobuf C++ files to our exported library.
 add_library(substrait_proto ${PROTO_SRCS} ${PROTO_HDRS} ProtoUtils.cpp
                             ProtoUtils.h)
-set_target_properties(substrait_proto PROPERTIES PUBLIC_HEADER "${PROTO_HDRS}")
+target_sources(
+  substrait_proto PUBLIC FILE_SET HEADERS BASE_DIRS
+                         ${PROTO_OUTPUT_TOPLEVEL_DIR} FILES ${PROTO_HDRS})
 
 # Include the protobuf library as a dependency to use this class.
 target_link_libraries(substrait_proto protobuf::libprotobuf)
@@ -95,5 +97,5 @@ target_include_directories(
 install(
   TARGETS substrait_proto
   EXPORT SubstraitTargets
-  LIBRARY
-  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/proto")
+  LIBRARY FILE_SET HEADERS
+          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/proto")

--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -86,5 +86,7 @@ target_link_libraries(substrait_proto protobuf::libprotobuf)
 # Make sure we can see our own generated include files.
 target_include_directories(
   substrait_proto
-  PUBLIC "${PROTO_OUTPUT_TOPLEVEL_DIR}/src"
-  PUBLIC "${protobuf_SOURCE_DIR}/src")
+  PUBLIC $<BUILD_INTERFACE:${PROTO_OUTPUT_TOPLEVEL_DIR}/src>
+         $<INSTALL_INTERFACE:include>
+  PUBLIC $<BUILD_INTERFACE:${protobuf_SOURCE_DIR}/src>
+         $<INSTALL_INTERFACE:include>)

--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -77,11 +77,17 @@ foreach(PROTO_FILE IN LISTS PROTOBUF_FILELIST)
 endforeach()
 
 # Add the generated protobuf C++ files to our exported library.
-add_library(substrait_proto ${PROTO_SRCS} ${PROTO_HDRS} ProtoUtils.cpp
-                            ProtoUtils.h)
+add_library(substrait_proto ${PROTO_SRCS} ${PROTO_HDRS} ProtoUtils.cpp)
 target_sources(
-  substrait_proto PUBLIC FILE_SET HEADERS BASE_DIRS
-                         ${PROTO_OUTPUT_TOPLEVEL_DIR} FILES ${PROTO_HDRS})
+  substrait_proto
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${PROTO_OUTPUT_TOPLEVEL_DIR}/src
+         ../..
+         FILES
+         ${PROTO_HDRS}
+         ProtoUtils.h)
 
 # Include the protobuf library as a dependency to use this class.
 target_link_libraries(substrait_proto protobuf::libprotobuf)
@@ -97,5 +103,4 @@ target_include_directories(
 install(
   TARGETS substrait_proto
   EXPORT SubstraitTargets
-  LIBRARY FILE_SET HEADERS
-          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/proto")
+  LIBRARY FILE_SET HEADERS)

--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -79,6 +79,7 @@ endforeach()
 # Add the generated protobuf C++ files to our exported library.
 add_library(substrait_proto ${PROTO_SRCS} ${PROTO_HDRS} ProtoUtils.cpp
                             ProtoUtils.h)
+set_target_properties(substrait_proto PROPERTIES PUBLIC_HEADER "${PROTO_HDRS}")
 
 # Include the protobuf library as a dependency to use this class.
 target_link_libraries(substrait_proto protobuf::libprotobuf)
@@ -90,3 +91,9 @@ target_include_directories(
          $<INSTALL_INTERFACE:include>
   PUBLIC $<BUILD_INTERFACE:${protobuf_SOURCE_DIR}/src>
          $<INSTALL_INTERFACE:include>)
+
+install(
+  TARGETS substrait_proto
+  EXPORT SubstraitTargets
+  LIBRARY
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/substrait/proto")

--- a/src/substrait/textplan/CMakeLists.txt
+++ b/src/substrait/textplan/CMakeLists.txt
@@ -42,3 +42,6 @@ target_include_directories(
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
+
+install(TARGETS error_listener parse_result symbol_table
+        EXPORT SubstraitTargets)

--- a/src/substrait/textplan/CMakeLists.txt
+++ b/src/substrait/textplan/CMakeLists.txt
@@ -36,8 +36,8 @@ target_link_libraries(
   date::date)
 
 # Provide access to the generated protobuffer headers hierarchy.
-target_include_directories(symbol_table
-                           PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/../..")
+target_include_directories(
+  symbol_table PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../..>)
 
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)

--- a/src/substrait/textplan/converter/CMakeLists.txt
+++ b/src/substrait/textplan/converter/CMakeLists.txt
@@ -54,5 +54,6 @@ add_library(substrait_textplan_normalizer ${NORMALIZER_SRCS})
 target_link_libraries(substrait_textplan_normalizer
                       substrait_textplan_converter)
 
-install(TARGETS substrait_textplan_converter substrait_base_proto_visitor
-                substrait_textplan_normalizer EXPORT SubstraitTargets)
+install(TARGETS planconverter substrait_textplan_converter
+                substrait_base_proto_visitor substrait_textplan_normalizer
+        EXPORT SubstraitTargets)

--- a/src/substrait/textplan/converter/CMakeLists.txt
+++ b/src/substrait/textplan/converter/CMakeLists.txt
@@ -53,3 +53,6 @@ add_library(substrait_textplan_normalizer ${NORMALIZER_SRCS})
 
 target_link_libraries(substrait_textplan_normalizer
                       substrait_textplan_converter)
+
+install(TARGETS substrait_textplan_converter substrait_base_proto_visitor
+                substrait_textplan_normalizer EXPORT SubstraitTargets)

--- a/src/substrait/textplan/parser/CMakeLists.txt
+++ b/src/substrait/textplan/parser/CMakeLists.txt
@@ -44,4 +44,4 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-install(TARGETS substrait_textplan_loader EXPORT SubstraitTargets)
+install(TARGETS planparser substrait_textplan_loader EXPORT SubstraitTargets)

--- a/src/substrait/textplan/parser/CMakeLists.txt
+++ b/src/substrait/textplan/parser/CMakeLists.txt
@@ -43,3 +43,5 @@ target_link_libraries(planparser substrait_textplan_loader error_listener)
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
+
+install(TARGETS substrait_textplan_loader EXPORT SubstraitTargets)

--- a/src/substrait/textplan/parser/grammar/CMakeLists.txt
+++ b/src/substrait/textplan/parser/grammar/CMakeLists.txt
@@ -60,3 +60,5 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${GRAMMAR_DIR}/antlr4cpp_generated_src>)
 
 target_link_libraries(textplan_grammar antlr4_static)
+
+install(TARGETS textplan_grammar EXPORT SubstraitTargets)

--- a/src/substrait/textplan/parser/grammar/CMakeLists.txt
+++ b/src/substrait/textplan/parser/grammar/CMakeLists.txt
@@ -55,7 +55,8 @@ add_library(textplan_grammar ${ANTLR_SubstraitPlanLexer_CXX_OUTPUTS}
 
 message(STATUS "generated dir:  ${GRAMMAR_DIR}/antlr4cpp_generated_src")
 
-target_include_directories(textplan_grammar
-                           PUBLIC "${GRAMMAR_DIR}/antlr4cpp_generated_src")
+target_include_directories(
+  textplan_grammar
+  PUBLIC $<BUILD_INTERFACE:${GRAMMAR_DIR}/antlr4cpp_generated_src>)
 
 target_link_libraries(textplan_grammar antlr4_static)

--- a/src/substrait/type/CMakeLists.txt
+++ b/src/substrait/type/CMakeLists.txt
@@ -9,3 +9,5 @@ target_link_libraries(substrait_type substrait_common)
 if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
+
+install(TARGETS substrait_type EXPORT SubstraitTargets)

--- a/src/substrait/type/CMakeLists.txt
+++ b/src/substrait/type/CMakeLists.txt
@@ -3,6 +3,9 @@
 set(TYPE_SRCS Type.cpp)
 
 add_library(substrait_type ${TYPE_SRCS})
+target_sources(
+  substrait_type PUBLIC FILE_SET HEADERS BASE_DIRS ../../../include/ FILES
+                        ../../../include/substrait/type/Type.h)
 
 target_link_libraries(substrait_type substrait_common)
 
@@ -10,4 +13,7 @@ if(${SUBSTRAIT_CPP_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-install(TARGETS substrait_type EXPORT SubstraitTargets)
+install(
+  TARGETS substrait_type
+  EXPORT SubstraitTargets
+  FILE_SET HEADERS)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+set(ABSL_ENABLE_INSTALL ON)
 if(NOT ${ABSL_INCLUDED_WITH_PROTOBUF})
   set(ABSL_PROPAGATE_CXX_STD ON)
   add_subdirectory(abseil-cpp)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Ensure `option()` in subdirectories honors normal variables set here.
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
 set(ABSL_ENABLE_INSTALL ON)
 if(NOT ${ABSL_INCLUDED_WITH_PROTOBUF})
   set(ABSL_PROPAGATE_CXX_STD ON)
@@ -27,6 +30,7 @@ set(BUILD_TESTING OFF)
 add_subdirectory(protobuf-matchers)
 set(BUILD_TESTING ${PREVIOUS_BUILD_TESTING})
 
+set(YAML_CPP_INSTALL ON)
 set(YAML_CPP_BUILD_TESTS
     OFF
     CACHE BOOL "Enable testing")


### PR DESCRIPTION
This allows to run `cmake --install .` to install the project to a
system such that it can be consumed with `find_package()`. This required
the following changes:

* Add `install(TARGET ...)` commands for all library and executable targets.
* Add all public header files to the `HEADER` `FILE_SET` of their respective target.
* Export all these targets to an export set and `install(EXPORT ...)` that export set.
* Provide install-time paths for several `target_include_directories()`,
  some of which are empty because the headers are not installed.

Since some of the library targets depend on external projects (`abseil-cpp`
and `yaml-cpp`), the install logic of these projects also needs to be enabled.

This change is not only necessary to actually install the project, but
also to consume it via `add_subdirectory` from any project that,
itself, is installable. (All dependencies of installable targets must be
installable.)