### PR TITLE
fix: Use CXX compiler of main project for ANTLR external project.

### DIFF
--- a/third_party/antlr4/cmake/ExternalAntlr4Cpp.cmake
+++ b/third_party/antlr4/cmake/ExternalAntlr4Cpp.cmake
@@ -97,7 +97,8 @@ if(ANTLR4_ZIP_REPOSITORY)
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
           -DDISABLE_WARNINGS:BOOL=ON
-	  -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
           # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
           # -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} # alternatively, compile the runtime with the same C++ standard as the outer project
       INSTALL_COMMAND ""
@@ -117,7 +118,8 @@ else()
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
           -DDISABLE_WARNINGS:BOOL=ON
-	  -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
           # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
           # -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} # alternatively, compile the runtime with the same C++ standard as the outer project
       INSTALL_COMMAND ""


### PR DESCRIPTION
This PR adds the `-DCMAKE_CXX_COMPILER` flag to the CMake flags of the external project for ANTLR. Without that, the external project uses the system default, which may not be what the user wants (and even be broken).