### PR TITLE
Don't concatenate paths in `--proto_path`

### DIFF
--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -67,7 +67,8 @@ foreach(PROTO_FILE IN LISTS PROTOBUF_FILELIST)
     OUTPUT ${PROTO_SRC} ${PROTO_HDR}
     COMMAND
       protobuf::protoc
-      "--proto_path=${GENERATED_PROTO_TOPLEVEL_DIR}:${protobuf_SOURCE_DIR}/src"
+      "--proto_path=${GENERATED_PROTO_TOPLEVEL_DIR}"
+      "--proto_path=${protobuf_SOURCE_DIR}/src"
       "--cpp_out=${PROTO_OUTPUT_MIDLEVEL_DIR}" ${GENERATED_PROTO_FILE}
     DEPENDS ${GENERATED_PROTOBUF_LIST} protobuf::protoc
     COMMENT "Generated C++ protobuf module for ${PROTO_FILE}"

--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -66,8 +66,7 @@ foreach(PROTO_FILE IN LISTS PROTOBUF_FILELIST)
   add_custom_command(
     OUTPUT ${PROTO_SRC} ${PROTO_HDR}
     COMMAND
-      protobuf::protoc
-      "--proto_path=${GENERATED_PROTO_TOPLEVEL_DIR}"
+      protobuf::protoc "--proto_path=${GENERATED_PROTO_TOPLEVEL_DIR}"
       "--proto_path=${protobuf_SOURCE_DIR}/src"
       "--cpp_out=${PROTO_OUTPUT_MIDLEVEL_DIR}" ${GENERATED_PROTO_FILE}
     DEPENDS ${GENERATED_PROTOBUF_LIST} protobuf::protoc


### PR DESCRIPTION
`protoc`'s `--proto_path` argument is expected to be provided multiple times if multiple directories are to be considered. Concatenating with `:` is invalid on some systems (Windows):

```sh
> protoc --help
  -IPATH, --proto_path=PATH   Specify the directory in which to search for
                              imports.  May be specified multiple times;
                              directories will be searched in order.  If not
                              given, the current working directory is used.
                              If not found in any of the these directories,
                              the --descriptor_set_in descriptors will be
                              checked for required proto file.
```