### PR TITLE
Prevent gtest compiler/link errors on windows

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -16,7 +16,9 @@ add_subdirectory(fmt)
 
 if(WIN32)
   # For Windows: Prevent overriding the parent project's compiler/linker settings
-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  set(gtest_force_shared_crt
+      ON
+      CACHE BOOL "" FORCE)
 endif()
 
 find_package(GTest QUIET)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -13,6 +13,12 @@ include(datetime.cmake)
 
 add_subdirectory(fmt)
 
+
+if(WIN32)
+  # For Windows: Prevent overriding the parent project's compiler/linker settings
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+endif()
+
 find_package(GTest QUIET)
 if(NOT ${GTEST_FOUND})
   message(STATUS "Retrieving external GoogleTest library.")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -13,7 +13,6 @@ include(datetime.cmake)
 
 add_subdirectory(fmt)
 
-
 if(WIN32)
   # For Windows: Prevent overriding the parent project's compiler/linker settings
   set(gtest_force_shared_crt


### PR DESCRIPTION
Substrait-cpp is (i assume) intended to embed into other projects, so other subprojects should adhere to parent projects' settings. For GTest on windows, this requires that `gtest_force_shared_crt ` is enabled ([doc](https://github.com/google/googletest/blob/main/googletest/README.md)).