### PR TITLE
Set ANTLR4CPP_STATIC for everything that links against ANTLR

### DIFF
--- a/src/substrait/textplan/parser/grammar/CMakeLists.txt
+++ b/src/substrait/textplan/parser/grammar/CMakeLists.txt
@@ -61,4 +61,9 @@ target_include_directories(
 
 target_link_libraries(textplan_grammar antlr4_static)
 
+# Things which link against textplan_grammar (and pull in antlr4 headers) should
+# always set 'ANTLR4CPP_STATIC', to avoid declaring things in the antlr4
+# headers as dllexport'ed.
+target_compile_definitions(textplan_grammar PUBLIC ANTLR4CPP_STATIC)
+
 install(TARGETS textplan_grammar EXPORT SubstraitTargets)


### PR DESCRIPTION
It isn't sufficient to rely on a single [`add_definitions`](https://github.com/substrait-io/substrait-cpp/blob/cc8d08af7a7ff4b65d0081fc18f9bb243fe85824/src/substrait/textplan/parser/grammar/CMakeLists.txt#L8) when defining this. Other things which pulls in ANTLR headers _must_ define this as well - if not, we end up with very hard to debug symbol visibility errors.

Set it as a public compile definition on the target to ensure the definition propagates.