### PR TITLE
Don't define member functions inside a nested namespace

### DIFF
--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -12,7 +12,7 @@
 #include "substrait/textplan/Location.h"
 #include "substrait/textplan/StructuredSymbolData.h"
 
-namespace io::substrait::textplan {
+using namespace io::substrait::textplan;
 
 const std::string& symbolTypeName(SymbolType type) {
   static std::vector<std::string> names = {
@@ -60,13 +60,17 @@ const SymbolInfo SymbolInfo::kUnknown = {
     std::nullopt,
     std::nullopt};
 
-bool operator==(const SymbolInfo& left, const SymbolInfo& right) {
+bool io::substrait::textplan::operator==(
+    const SymbolInfo& left,
+    const SymbolInfo& right) {
   return (left.name == right.name) &&
       (left.sourceLocation == right.sourceLocation) &&
       (left.type == right.type);
 }
 
-bool operator!=(const SymbolInfo& left, const SymbolInfo& right) {
+bool io::substrait::textplan::operator!=(
+    const SymbolInfo& left,
+    const SymbolInfo& right) {
   return !(left == right);
 }
 
@@ -288,5 +292,3 @@ std::string SymbolTable::toDebugString() const {
   }
   return result.str();
 }
-
-} // namespace io::substrait::textplan

--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -14,7 +14,7 @@
 
 using namespace io::substrait::textplan;
 
-const std::string& symbolTypeName(SymbolType type) {
+const std::string& io::substrait::textplan::symbolTypeName(SymbolType type) {
   static std::vector<std::string> names = {
       "kExtensionSpace",
       "kFunction",


### PR DESCRIPTION
This trips up MSVC, in that member functions aren't properly included in the object files of the various translation units.

e.g. `DumpBin` of `symbol_table.lib`:
![image](https://github.com/user-attachments/assets/09635761-3937-4174-83ad-999cb214d74c)


Generally, this can be fixed by having a `using` declaration in a .cpp file to enable the namespace. From my experience, a general good practice is to never nest definitions in namespaces, unless the namespace is only visible from within a translation unit (e.g. a `detail` namespace inside a .cpp file).

This doesn't fix all of the places in the code where this pattern is used - only the (narrow) compile path that i've been excercising. Someone should probably go through the rest of the codebase and apply this - will be needed if/when a windows CI pipeline is added.