### PR TITLE
Fix namespace pollution on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ option(
   "Enable substrait-cpp tests. This will enable all other build options automatically."
   ON)
 
+set(SUBSTRAIT_CPP_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Local files come first.
 include_directories(include)
 include_directories(src)

--- a/src/substrait/common/CMakeLists.txt
+++ b/src/substrait/common/CMakeLists.txt
@@ -19,10 +19,8 @@ add_dependencies(
   absl::status
   absl::statusor)
 target_include_directories(
-  substrait_io
-  INTERFACE
-    $<BUILD_INTERFACE:${SUBSTRAIT_CPP_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:include>)
+  substrait_io INTERFACE $<BUILD_INTERFACE:${SUBSTRAIT_CPP_INCLUDE_DIR}>
+                         $<INSTALL_INTERFACE:include>)
 target_link_libraries(substrait_io substrait_proto substrait_textplan_converter
                       substrait_textplan_loader absl::status absl::statusor)
 

--- a/src/substrait/common/CMakeLists.txt
+++ b/src/substrait/common/CMakeLists.txt
@@ -21,8 +21,8 @@ add_dependencies(
 target_include_directories(
   substrait_io
   INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../include/substrait/common>
-    $<INSTALL_INTERFACE:include/substrait/common>)
+    $<BUILD_INTERFACE:${SUBSTRAIT_CPP_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>)
 target_link_libraries(substrait_io substrait_proto substrait_textplan_converter
                       substrait_textplan_loader absl::status absl::statusor)
 


### PR DESCRIPTION
As described in https://github.com/substrait-io/substrait-cpp/issues/116, the `io.h` file in this project conflicts with `io.h` of windows.

This fixes that (in the somewhat narrow compilation path that i'm exercising) by removing `include/substrait/common` from the include path, and instead relying on the (already existing) full include-path namespacing instead of relative includes of `io.h`.