### PR TITLE
Don't throw away `visit` result in BasePlanProtoVisitor

### DIFF
--- a/src/substrait/textplan/converter/BasePlanProtoVisitor.h
+++ b/src/substrait/textplan/converter/BasePlanProtoVisitor.h
@@ -17,8 +17,8 @@ class BasePlanProtoVisitor {
   BasePlanProtoVisitor() = default;
 
   // visit() begins the traversal of the entire plan.
-  virtual void visit(const ::substrait::proto::Plan& plan) {
-    visitPlan(plan);
+  virtual std::any visit(const ::substrait::proto::Plan& plan) {
+    return visitPlan(plan);
   }
 
  protected:


### PR DESCRIPTION
`visitPlan` is marked `protected`, meaning that non-subclasses of `BasePlanProtoVisitor` (which is probably what'll initiate the `visit` most of the time) cannot have access to the `visit` result.

Is there a specific reason that the traversal result has been hidden? If not, i suggest this change.

If so, subclasses are obviously free to implement a `visitWithResult` function to do the same thing.