### PR TITLE
Add missing include

### DIFF
--- a/include/substrait/expression/DecimalLiteral.h
+++ b/include/substrait/expression/DecimalLiteral.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace substrait::proto {


### PR DESCRIPTION
int32_t, ... uses `<cstdint>`.