### PR TITLE
feat: update to Substrait 0.43, add min. precision timestamp support

### DIFF
--- a/src/substrait/textplan/PlanPrinterVisitor.cpp
+++ b/src/substrait/textplan/PlanPrinterVisitor.cpp
@@ -476,6 +476,8 @@ std::any PlanPrinterVisitor::visitType(const ::substrait::proto::Type& type) {
     case ::substrait::proto::Type::kMap:
     case ::substrait::proto::Type::kUserDefined:
     case ::substrait::proto::Type::kUserDefinedTypeReference:
+    case ::substrait::proto::Type::kPrecisionTimestamp:
+    case ::substrait::proto::Type::kPrecisionTimestampTz:
       errorListener_->addError(
           "Unsupported type requested: " + type.ShortDebugString());
       return std::string("UNSUPPORTED_TYPE");
@@ -572,6 +574,8 @@ std::any PlanPrinterVisitor::visitLiteral(
     case ::substrait::proto::Expression_Literal::kEmptyList:
     case ::substrait::proto::Expression_Literal::kEmptyMap:
     case ::substrait::proto::Expression_Literal::kUserDefined:
+    case ::substrait::proto::Expression_Literal::kPrecisionTimestamp:
+    case ::substrait::proto::Expression_Literal::kPrecisionTimestampTz:
       errorListener_->addError(
           "Literal of this type not yet supported: " +
           literal.ShortDebugString());

--- a/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
+++ b/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
@@ -175,6 +175,8 @@ std::any BasePlanProtoVisitor::visitType(const ::substrait::proto::Type& type) {
     case ::substrait::proto::Type::kUserDefined:
       return visitTypeUserDefined(type.user_defined());
     case ::substrait::proto::Type::kUserDefinedTypeReference:
+    case ::substrait::proto::Type::kPrecisionTimestamp:
+    case ::substrait::proto::Type::kPrecisionTimestampTz:
       SUBSTRAIT_UNSUPPORTED(
           "user_defined_type_reference was replaced by user_defined_type.  "
           "Please update your plan version.");
@@ -366,6 +368,9 @@ std::any BasePlanProtoVisitor::visitLiteral(
       return visitTypeMap(literal.empty_map());
     case ::substrait::proto::Expression_Literal::kUserDefined:
       return visitUserDefined(literal.user_defined());
+    case ::substrait::proto::Expression_Literal::kPrecisionTimestamp:
+    case ::substrait::proto::Expression_Literal::kPrecisionTimestampTz:
+      return std::nullopt;
     case ::substrait::proto::Expression_Literal::LITERAL_TYPE_NOT_SET:
       break;
   }

--- a/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
@@ -24,6 +24,13 @@
 #include "substrait/textplan/StructuredSymbolData.h"
 #include "substrait/textplan/SymbolTable.h"
 
+// The visitor should try and be tolerant of older plans.  This
+// requires calling deprecated APIs.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma gcc diagnostic push
+#pragma gcc diagnostic ignored "-Wdeprecated-declarations"
+
 namespace io::substrait::textplan {
 
 namespace {
@@ -145,6 +152,14 @@ void setNullable(::substrait::proto::Type* type) {
       break;
     case ::substrait::proto::Type::kUserDefined:
       type->mutable_user_defined()->set_nullability(
+          ::substrait::proto::Type_Nullability_NULLABILITY_NULLABLE);
+      break;
+    case ::substrait::proto::Type::kPrecisionTimestamp:
+      type->mutable_precision_timestamp()->set_nullability(
+          ::substrait::proto::Type_Nullability_NULLABILITY_NULLABLE);
+      break;
+    case ::substrait::proto::Type::kPrecisionTimestampTz:
+      type->mutable_precision_timestamp_tz()->set_nullability(
           ::substrait::proto::Type_Nullability_NULLABILITY_NULLABLE);
       break;
     case ::substrait::proto::Type::kUserDefinedTypeReference:
@@ -2166,3 +2181,6 @@ bool SubstraitPlanRelationVisitor::hasSubquery(
 }
 
 } // namespace io::substrait::textplan
+
+#pragma clang diagnostic pop
+#pragma gcc diagnostic pop

--- a/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
@@ -24,6 +24,13 @@
 #include "substrait/textplan/StructuredSymbolData.h"
 #include "substrait/textplan/SymbolTable.h"
 
+// The visitor should try and be tolerant of older plans.  This
+// requires calling deprecated APIs.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma gcc diagnostic push
+#pragma gcc diagnostic ignored "-Wdeprecated-declarations"
+
 namespace io::substrait::textplan {
 
 namespace {
@@ -145,6 +152,14 @@ void setNullable(::substrait::proto::Type* type) {
       break;
     case ::substrait::proto::Type::kUserDefined:
       type->mutable_user_defined()->set_nullability(
+          ::substrait::proto::Type_Nullability_NULLABILITY_NULLABLE);
+      break;
+    case ::substrait::proto::Type::kPrecisionTimestamp:
+      type->mutable_precision_timestamp()->set_nullability(
+          ::substrait::proto::Type_Nullability_NULLABILITY_NULLABLE);
+      break;
+    case ::substrait::proto::Type::kPrecisionTimestampTz:
+      type->mutable_precision_timestamp_tz()->set_nullability(
           ::substrait::proto::Type_Nullability_NULLABILITY_NULLABLE);
       break;
     case ::substrait::proto::Type::kUserDefinedTypeReference:
@@ -2278,3 +2293,6 @@ bool SubstraitPlanSubqueryRelationVisitor::isWithinSubquery(
 }
 
 } // namespace io::substrait::textplan
+
+#pragma clang diagnostic pop
+#pragma gcc diagnostic pop

--- a/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
@@ -9,6 +9,13 @@
 #include "substrait/textplan/SymbolTable.h"
 #include "substrait/type/Type.h"
 
+// The visitor should try and be tolerant of older plans.  This
+// requires calling deprecated APIs.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma gcc diagnostic push
+#pragma gcc diagnostic ignored "-Wdeprecated-declarations"
+
 namespace io::substrait::textplan {
 
 std::any SubstraitPlanTypeVisitor::visitLiteral_basic_type(
@@ -202,3 +209,6 @@ bool SubstraitPlanTypeVisitor::insideStructLiteralWithExternalType(
 }
 
 } // namespace io::substrait::textplan
+
+#pragma clang diagnostic pop
+#pragma gcc diagnostic pop


### PR DESCRIPTION
Update to Substrait v0.43.0, which is the next version, and add minimal support for precision timestamp support, which is the main change since the previously used v0.42.1. The minimal support is achieved by adding the new type cases to the type switches, where they either produce "not implemented" errors or do the simple functionality of setting nullability of the type, as well as suppressing warnings of using depcreated protobuf accessors in the places where these were not suppressed yet.