### PR TITLE
fix: use proper string concatenation for error on unsupported types

### DIFF
--- a/src/substrait/type/Type.cpp
+++ b/src/substrait/type/Type.cpp
@@ -40,7 +40,7 @@ ParameterizedTypePtr decodeType(
     bool nullable,
     const std::vector<ParameterizedTypePtr>& parameterTypes) {
   SUBSTRAIT_UNSUPPORTED(
-      "Unsupported parameter type: " + TypeTraits<Kind>::kTypeString);
+      std::string("Unsupported parameter type: ") + TypeTraits<Kind>::kTypeString);
 }
 
 template <>

--- a/src/substrait/type/Type.cpp
+++ b/src/substrait/type/Type.cpp
@@ -40,7 +40,8 @@ ParameterizedTypePtr decodeType(
     bool nullable,
     const std::vector<ParameterizedTypePtr>& parameterTypes) {
   SUBSTRAIT_UNSUPPORTED(
-      std::string("Unsupported parameter type: ") + TypeTraits<Kind>::kTypeString);
+      std::string("Unsupported parameter type: ") +
+      TypeTraits<Kind>::kTypeString);
 }
 
 template <>


### PR DESCRIPTION
The previous default template instances of `decodeType` for parametrized types used a "concatenation" on two char pointers, which doesn't work. This PR fixes that by making one of the two an `std::string`. The error did not show up until now because all supported types have specializations of the template.