### PR TITLE
Re-format project + bump clang-format version

### DIFF
--- a/export/planloader/planloader.cpp
+++ b/export/planloader/planloader.cpp
@@ -2,8 +2,8 @@
 
 #include "planloader.h"
 
-#include <limits>
 #include <substrait/common/Io.h>
+#include <limits>
 
 extern "C" {
 
@@ -20,17 +20,16 @@ SerializedPlan* load_substrait_plan(const char* filename) {
   auto planOrError = io::substrait::loadPlan(filename);
   if (!planOrError.ok()) {
     auto errMsg = planOrError.status().message();
-    newPlan->error_message = new char[errMsg.length()+1];
-    strncpy(newPlan->error_message, errMsg.data(), errMsg.length()+1);
+    newPlan->error_message = new char[errMsg.length() + 1];
+    strncpy(newPlan->error_message, errMsg.data(), errMsg.length() + 1);
     return newPlan;
   }
   ::substrait::proto::Plan plan = *planOrError;
   std::string text = plan.SerializeAsString();
-  newPlan->buffer = new unsigned char[text.length()+1];
-  memcpy(newPlan->buffer, text.data(), text.length()+1);
-  newPlan->size = static_cast<int32_t>(
-            text.length() &
-            std::numeric_limits<int32_t>::max());
+  newPlan->buffer = new unsigned char[text.length() + 1];
+  memcpy(newPlan->buffer, text.data(), text.length() + 1);
+  newPlan->size =
+      static_cast<int32_t>(text.length() & std::numeric_limits<int32_t>::max());
   return newPlan;
 }
 
@@ -49,7 +48,7 @@ const char* save_substrait_plan(
     const char* filename,
     io::substrait::PlanFileFormat format) {
   ::substrait::proto::Plan plan;
-  std::string data((const char*) plan_data, plan_data_length);
+  std::string data((const char*)plan_data, plan_data_length);
   plan.ParseFromString(data);
   auto result = io::substrait::savePlan(plan, filename, format);
   if (!result.ok()) {
@@ -58,4 +57,4 @@ const char* save_substrait_plan(
   return nullptr;
 }
 
-}  // extern "C"
+} // extern "C"

--- a/export/planloader/planloader.h
+++ b/export/planloader/planloader.h
@@ -9,12 +9,12 @@ extern "C" {
 
 using SerializedPlan = struct {
   // If set, contains a serialized ::substrait::proto::Plan object.
-  unsigned char *buffer;
+  unsigned char* buffer;
   // If buffer is set, this is the size of the buffer.
   int32_t size;
   // If null the buffer is valid, otherwise this points to a null terminated
   // error string.
-  char *error_message;
+  char* error_message;
 };
 
 // Load a Substrait plan (in any format) from disk.
@@ -43,4 +43,4 @@ const char* save_substrait_plan(
 
 // NOLINTEND(readability-identifier-naming)
 
-}  // extern "C"
+} // extern "C"

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -3,4 +3,4 @@
 SCRIPTDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 WORKDIR="$( cd $SCRIPTDIR/.. && pwd )"
 
-find $WORKDIR/src $WORKDIR/include \( -name '*.h' -o -name '*.cpp' \) -exec clang-format -style=file -i {} \;
+find $WORKDIR/src $WORKDIR/include \( -name '*.h' -o -name '*.cpp' \) -exec clang-format-15 -style=file -i {} \;

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -18,7 +18,7 @@ sudo --preserve-env apt install -y \
   clang-tidy \
   git \
   wget \
-  clang-format \
+  clang-format-15 \
   uuid-dev \
   default-jre \
   libcurl4-openssl-dev


### PR DESCRIPTION
Setting a fixed clang-format version should avoid confusion about nit-ty details in between clang-format versions. Pick 15; it should be available on all developer platforms, and is fairly recent.