### PR TITLE
build: suppress warnings in external dependencies

### DIFF
--- a/third_party/protobuf.cmake
+++ b/third_party/protobuf.cmake
@@ -15,5 +15,12 @@ FetchContent_Declare(Protobuf
         GIT_TAG v28.2
         OVERRIDE_FIND_PACKAGE
 )
+
+# Disable warnings for dependency targets.
 set(protobuf_BUILD_TESTS OFF CACHE INTERNAL "")
+if(MSVC)
+  add_compile_options("/W0")
+else()
+  add_compile_options("-w")
+endif()
 FetchContent_MakeAvailable(Protobuf GTest)


### PR DESCRIPTION
This PR adds compiler flags to the build process of the external dependencies downloaded and built via `FetchContent`, namely GTest and Protobuf. That build process generated more than 2k warnings in my system and, since those are well-tested external libraries, are almost certain all harmless.