### PR TITLE
build(clang-tidy): add project prefix to clang tidy variable name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,9 @@ include(cmake/clang-tidy.cmake)
 unset(CMAKE_CXX_CLANG_TIDY)
 
 add_subdirectory(third_party)
-set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND}) # Re-enable clang-tidy.
+
+# Re-enable clang-tidy.
+set(CMAKE_CXX_CLANG_TIDY ${SUBSTRAIT_CPP_CLANG_TIDY_COMMAND})
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 include(BuildUtils)

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -20,12 +20,13 @@ if(SUBSTRAIT_CPP_ENABLE_CLANG_TIDY)
 
   # Assemble command line.
   set(CLANG_TIDY_CONFIG_FILE "${CMAKE_SOURCE_DIR}/.clang-tidy")
-  set(CLANG_TIDY_COMMAND
+  set(SUBSTRAIT_CPP_CLANG_TIDY_COMMAND
       "${CLANG_TIDY_EXE};--config-file=${CLANG_TIDY_CONFIG_FILE}")
   set(CMAKE_CXX_CLANG_TIDY_EXPORT_FIXES_DIR
       "${CMAKE_BINARY_DIR}/clang-tidy-fixes")
-  message(STATUS "clang-tidy enabled, command: ${CLANG_TIDY_COMMAND}")
+  message(
+    STATUS "clang-tidy enabled, command: ${SUBSTRAIT_CPP_CLANG_TIDY_COMMAND}")
 endif(SUBSTRAIT_CPP_ENABLE_CLANG_TIDY)
 
 # Enable clang-tidy for all C++ targets.
-set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND})
+set(CMAKE_CXX_CLANG_TIDY ${SUBSTRAIT_CPP_CLANG_TIDY_COMMAND})

--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -74,10 +74,12 @@ foreach(PROTO_FILE IN LISTS PROTOBUF_FILELIST)
   list(APPEND PROTO_SRCS ${PROTO_SRC})
 endforeach()
 
-# Add the generated protobuf C++ files to our exported library.
+# Add the generated protobuf C++ files to our exported library. Disable
+# clang-tidy because the generated code doesn't pass.
 unset(CMAKE_CXX_CLANG_TIDY)
 add_library(substrait_proto ${PROTO_SRCS} ${PROTO_HDRS} ProtoUtils.cpp)
-set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND}) # Re-enable clang-tidy.
+set(CMAKE_CXX_CLANG_TIDY ${SUBSTRAIT_CPP_CLANG_TIDY_COMMAND})
+
 target_sources(
   substrait_proto
   PUBLIC FILE_SET


### PR DESCRIPTION
This PR fixes a variable name clash between this project and potential downstream projects. If they both use the variable `CLANG_TIDY_COMMAND` to enable or disable `clang-tidy`, it is impossible to activate `clang-tidy` for the downstream project and deactivate it for this project. See substrait-io/substrait-mlir-contrib#204.