### PR TITLE
build(clang-tidy): improve CMake setup and apply fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,15 +56,10 @@ set(ANTLR_EXECUTABLE "${ANTLR_EXECUTABLE_DIR}/antlr.jar")
 include_directories(include)
 include_directories(src)
 
-include(cmake/clang-tidy.cmake)
-
-# Disable clang-tidy for third-party dependencies.
-unset(CMAKE_CXX_CLANG_TIDY)
-
 add_subdirectory(third_party)
 
-# Re-enable clang-tidy.
-set(CMAKE_CXX_CLANG_TIDY ${SUBSTRAIT_CPP_CLANG_TIDY_COMMAND})
+# Set up clang-tidy after third-party dependencies.
+include(cmake/clang-tidy.cmake)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 include(BuildUtils)

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -21,7 +21,8 @@ if(SUBSTRAIT_CPP_ENABLE_CLANG_TIDY)
   # Assemble command line.
   set(CLANG_TIDY_CONFIG_FILE "${CMAKE_SOURCE_DIR}/.clang-tidy")
   set(SUBSTRAIT_CPP_CLANG_TIDY_COMMAND
-      "${CLANG_TIDY_EXE};--config-file=${CLANG_TIDY_CONFIG_FILE}")
+      "${CLANG_TIDY_EXE};--config-file=${CLANG_TIDY_CONFIG_FILE};"
+      "--header-filter=${CMAKE_SOURCE_DIR}/(export|include|lib|src)/.*")
   set(CMAKE_CXX_CLANG_TIDY_EXPORT_FIXES_DIR
       "${CMAKE_BINARY_DIR}/clang-tidy-fixes")
   message(

--- a/export/planloader/planloader.cpp
+++ b/export/planloader/planloader.cpp
@@ -24,7 +24,7 @@ SerializedPlan* load_substrait_plan(const char* filename) {
     strncpy(newPlan->error_message, errMsg.data(), errMsg.length() + 1);
     return newPlan;
   }
-  ::substrait::proto::Plan plan = *planOrError;
+  const ::substrait::proto::Plan& plan = *planOrError;
   std::string text = plan.SerializeAsString();
   newPlan->buffer = new unsigned char[text.length() + 1];
   memcpy(newPlan->buffer, text.data(), text.length() + 1);

--- a/src/substrait/common/PlanTransformerTool.cpp
+++ b/src/substrait/common/PlanTransformerTool.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 
   auto planOrError = io::substrait::loadPlan(argv[1]);
   if (!planOrError.ok()) {
-    std::cerr << planOrError.status() << std::endl;
+    std::cerr << planOrError.status() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
 
   auto result = io::substrait::savePlan(*planOrError, argv[2], format);
   if (!result.ok()) {
-    std::cerr << result << std::endl;
+    std::cerr << result << '\n';
     return EXIT_FAILURE;
   }
 

--- a/src/substrait/expression/DecimalLiteral.cpp
+++ b/src/substrait/expression/DecimalLiteral.cpp
@@ -56,7 +56,10 @@ DecimalLiteral DecimalLiteral::fromString(
   }
   std::uint8_t valueBytes[16];
   uint128ToBytes(v, valueBytes);
-  return {std::string((const char*)valueBytes, 16), precision, scale};
+  return {
+      std::string(reinterpret_cast<const char*>(valueBytes), 16),
+      precision,
+      scale};
 }
 
 bool DecimalLiteral::isValid() {

--- a/src/substrait/proto/CMakeLists.txt
+++ b/src/substrait/proto/CMakeLists.txt
@@ -74,10 +74,13 @@ foreach(PROTO_FILE IN LISTS PROTOBUF_FILELIST)
   list(APPEND PROTO_SRCS ${PROTO_SRC})
 endforeach()
 
-# Add the generated protobuf C++ files to our exported library. Disable
-# clang-tidy because the generated code doesn't pass.
+# Disable linters for generated code.
 unset(CMAKE_CXX_CLANG_TIDY)
+
+# Add the generated protobuf C++ files to our exported library.
 add_library(substrait_proto ${PROTO_SRCS} ${PROTO_HDRS} ProtoUtils.cpp)
+
+# Re-enable linters.
 set(CMAKE_CXX_CLANG_TIDY ${SUBSTRAIT_CPP_CLANG_TIDY_COMMAND})
 
 target_sources(

--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #include "substrait/textplan/SymbolTable.h"
 
+#include <algorithm>
 #include <any>
 #include <iomanip>
 #include <map>
@@ -27,7 +28,7 @@ const std::string& symbolTypeName(SymbolType type) {
       "kSourceDetail",
       "kField",
   };
-  auto typeNum = int32_t(type);
+  auto typeNum = static_cast<int32_t>(type);
   if (typeNum == -1) {
     static std::string unknown = "kUnknown";
     return unknown;
@@ -136,9 +137,7 @@ void SymbolTable::setParentQueryLocation(
   int highestIndex = -1;
   for (const auto& sym : symbols_) {
     if (sym->parentQueryLocation == location) {
-      if (sym->parentQueryIndex > highestIndex) {
-        highestIndex = sym->parentQueryIndex;
-      }
+      highestIndex = std::max(sym->parentQueryIndex, highestIndex);
     }
   }
   symbols_[index]->parentQueryIndex = highestIndex + 1;
@@ -236,7 +235,7 @@ std::string SymbolTable::toDebugString() const {
     if (!relationData->subQueryPipelines.empty()) {
       result << " SQC=" << relationData->subQueryPipelines.size();
     }
-    result << std::endl;
+    result << '\n';
 
     int32_t fieldNum = 0;
     for (const auto& field : relationData->fieldReferences) {
@@ -248,7 +247,7 @@ std::string SymbolTable::toDebugString() const {
       if (!field->alias.empty()) {
         result << " " << field->alias;
       }
-      result << std::endl;
+      result << '\n';
     }
 
     for (const auto& field : relationData->generatedFieldReferences) {
@@ -266,7 +265,7 @@ std::string SymbolTable::toDebugString() const {
       } else if (!field->alias.empty()) {
         result << " " << field->alias;
       }
-      result << std::endl;
+      result << '\n';
     }
 
     int32_t outputFieldNum = 0;
@@ -279,12 +278,12 @@ std::string SymbolTable::toDebugString() const {
       if (!field->alias.empty()) {
         result << " " << field->alias;
       }
-      result << std::endl;
+      result << '\n';
     }
     textAlreadyWritten = true;
   }
   if (textAlreadyWritten) {
-    result << std::endl;
+    result << '\n';
   }
   return result.str();
 }

--- a/src/substrait/textplan/converter/Tool.cpp
+++ b/src/substrait/textplan/converter/Tool.cpp
@@ -17,7 +17,7 @@ namespace {
 void convertPlanToText(const char* filename) {
   auto planOrError = loadPlan(filename);
   if (!planOrError.ok()) {
-    std::cerr << planOrError.status() << std::endl;
+    std::cerr << planOrError.status() << '\n';
     return;
   }
 
@@ -29,7 +29,7 @@ void convertPlanToText(const char* filename) {
   auto errors = result.getAllErrors();
   if (!errors.empty()) {
     for (const auto& err : errors) {
-      std::cerr << err << std::endl;
+      std::cerr << err << '\n';
     }
   }
   std::cout << textResult;

--- a/src/substrait/textplan/converter/tests/BinaryToTextPlanConversionTest.cpp
+++ b/src/substrait/textplan/converter/tests/BinaryToTextPlanConversionTest.cpp
@@ -685,7 +685,7 @@ TEST_F(BinaryToTextPlanConversionTest, FullSample) {
   ASSERT_TRUE(jsonOrError.ok());
   auto planOrError = loadFromJson(*jsonOrError);
   ASSERT_TRUE(planOrError.ok());
-  auto plan = *planOrError;
+  const auto& plan = *planOrError;
   EXPECT_THAT(plan.extensions_size(), ::testing::Eq(7));
 
   auto expectedOutputOrError = readFromFile("data/q6_first_stage.golden.splan");

--- a/src/substrait/textplan/parser/ParseText.cpp
+++ b/src/substrait/textplan/parser/ParseText.cpp
@@ -23,11 +23,11 @@ std::optional<antlr4::ANTLRInputStream> loadTextFile(
     std::string_view filename) {
   std::ifstream stream(std::string{filename});
   if (stream.bad() || stream.fail()) {
-    std::cout << "Bad stream." << std::endl;
+    std::cout << "Bad stream." << '\n';
     return std::nullopt;
   }
   if (!stream.is_open()) {
-    std::cout << "Stream is not open." << std::endl;
+    std::cout << "Stream is not open." << '\n';
     return std::nullopt;
   }
   return {stream};

--- a/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
@@ -35,7 +35,7 @@ const std::string kSortDirectionPrefix = "sortdirection";
 
 const std::string kIntermediateNodeName = "intermediate";
 
-enum RelationFilterBehavior {
+enum RelationFilterBehavior : std::int8_t {
   kDefault = 0,
   kBestEffort = 1,
   kPostJoin = 2,

--- a/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
@@ -33,7 +33,7 @@ const std::string kAggregationInvocationPrefix = "aggregationinvocation";
 const std::string kJoinTypePrefix = "jointype";
 const std::string kSortDirectionPrefix = "sortdirection";
 
-enum RelationFilterBehavior {
+enum RelationFilterBehavior : std::int8_t {
   kDefault = 0,
   kBestEffort = 1,
   kPostJoin = 2,

--- a/src/substrait/textplan/parser/Tool.cpp
+++ b/src/substrait/textplan/parser/Tool.cpp
@@ -12,13 +12,13 @@ namespace {
 void readText(const char* filename) {
   auto stream = io::substrait::textplan::loadTextFile(filename);
   if (!stream.has_value()) {
-    std::cerr << "An error occurred while reading: " << filename << std::endl;
+    std::cerr << "An error occurred while reading: " << filename << '\n';
     return;
   }
   auto parseResult = io::substrait::textplan::parseStream(&*stream);
   if (!parseResult.successful()) {
     for (const std::string& msg : parseResult.getAllErrors()) {
-      std::cout << msg << std::endl;
+      std::cout << msg << '\n';
     }
     return;
   }
@@ -28,7 +28,7 @@ void readText(const char* filename) {
       parseResult.getSymbolTable(), &errorListener);
   if (errorListener.hasErrors()) {
     for (const std::string& msg : errorListener.getErrorMessages()) {
-      std::cout << msg << std::endl;
+      std::cout << msg << '\n';
     }
     return;
   }

--- a/src/substrait/textplan/parser/grammar/CMakeLists.txt
+++ b/src/substrait/textplan/parser/grammar/CMakeLists.txt
@@ -27,8 +27,15 @@ message(
   STATUS
     "ANTLR4 generated files: ${ANTLR_SubstraitPlanLexer_CXX_OUTPUTS} ${ANTLR_SubstraitPlanParser_CXX_OUTPUTS}"
 )
+
+# Disable linters for generated code.
+unset(CMAKE_CXX_CLANG_TIDY)
+
 add_library(textplan_grammar ${ANTLR_SubstraitPlanLexer_CXX_OUTPUTS}
                              ${ANTLR_SubstraitPlanParser_CXX_OUTPUTS})
+
+# Re-enable linters.
+set(CMAKE_CXX_CLANG_TIDY ${SUBSTRAIT_CPP_CLANG_TIDY_COMMAND})
 
 set(GRAMMAR_DIR ${CMAKE_CURRENT_BINARY_DIR})
 message(STATUS "generated dir:  ${GRAMMAR_DIR}/antlr4cpp_generated_src")

--- a/src/substrait/textplan/tests/ParseResultMatchers.cpp
+++ b/src/substrait/textplan/tests/ParseResultMatchers.cpp
@@ -56,7 +56,7 @@ bool stringEqSquashingWhitespace(
                   << have.substr(atHave - have.begin(), 20) << "|"
                   << " should be |"
                   << expected.substr(atExpected - expected.begin(), 20) << "|"
-                  << std::endl;
+                  << '\n';
       }
       return false;
     }
@@ -164,7 +164,7 @@ class HasSymbolsMatcher {
           expectedSymbolsSorted.end(),
           std::back_inserter(extraSymbols));
       if (!extraSymbols.empty()) {
-        *listener << std::endl << "          with extra symbols: ";
+        *listener << '\n' << "          with extra symbols: ";
         for (const auto& symbol : extraSymbols) {
           *listener << " \"" << symbol << "\"";
         }
@@ -314,7 +314,7 @@ class HasSymbolsWithTypesMatcher {
       std::vector<std::string> extraSymbols =
           orderedSetDifference(actualSymbols, expectedSymbols_);
       if (!extraSymbols.empty()) {
-        *listener << std::endl << "          with extra symbols";
+        *listener << '\n' << "          with extra symbols";
         DescribeTypes(listener);
         *listener << ": ";
         for (const auto& symbol : extraSymbols) {

--- a/src/substrait/textplan/tests/RoundtripTest.cpp
+++ b/src/substrait/textplan/tests/RoundtripTest.cpp
@@ -38,7 +38,7 @@ std::string addLineNumbers(const std::string& text) {
   int lineNum = 0;
   std::string line;
   while (std::getline(input, line, '\n')) {
-    result << std::setw(4) << ++lineNum << " " << line << std::endl;
+    result << std::setw(4) << ++lineNum << " " << line << '\n';
   }
   return result.str();
 }
@@ -72,13 +72,13 @@ std::vector<std::string> getTestCases() {
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(RoundTripBinaryToTextFixture);
 
 TEST_P(RoundTripBinaryToTextFixture, RoundTrip) {
-  auto filename = GetParam();
+  const auto& filename = GetParam();
   auto jsonOrError = readFromFile(filename);
   ASSERT_TRUE(jsonOrError.ok());
   auto planOrError = loadFromJson(*jsonOrError);
   ASSERT_TRUE(planOrError.ok());
 
-  auto plan = *planOrError;
+  const auto& plan = *planOrError;
 
   auto textResult = parseBinaryPlan(plan);
   auto textSymbols = textResult.getSymbolTable().getSymbols();
@@ -89,10 +89,10 @@ TEST_P(RoundTripBinaryToTextFixture, RoundTrip) {
   textResult.addErrors(errorListener.getErrorMessages());
 
   ASSERT_THAT(textResult, ParsesOk())
-      << std::endl
-      << "Initial result:" << std::endl
-      << addLineNumbers(outputText) << std::endl
-      << textResult.getSymbolTable().toDebugString() << std::endl;
+      << '\n'
+      << "Initial result:" << '\n'
+      << addLineNumbers(outputText) << '\n'
+      << textResult.getSymbolTable().toDebugString() << '\n';
 
   auto stream = loadTextString(outputText);
   auto result = parseStream(&stream);
@@ -108,10 +108,10 @@ TEST_P(RoundTripBinaryToTextFixture, RoundTrip) {
           AsBinaryPlan(IgnoringFields(
               {"substrait.proto.RelCommon.Emit.output_mapping"},
               EqualsProto(normalizedPlan)))))
-      << std::endl
-      << "Intermediate result:" << std::endl
-      << addLineNumbers(outputText) << std::endl
-      << result.getSymbolTable().toDebugString() << std::endl;
+      << '\n'
+      << "Intermediate result:" << '\n'
+      << addLineNumbers(outputText) << '\n'
+      << result.getSymbolTable().toDebugString() << '\n';
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/substrait/textplan/tests/SymbolTableTest.cpp
+++ b/src/substrait/textplan/tests/SymbolTableTest.cpp
@@ -102,7 +102,7 @@ TEST_F(SymbolTableTest, LocationsUnchangedAfterCopy) {
   auto* ptr3 = &plan.extensions(0);
 
   const SymbolTable& table2 = table;
-  auto symbols = table2.getSymbols();
+  const auto& symbols = table2.getSymbols();
   ASSERT_THAT(
       symbolNames(symbols),
       ::testing::ElementsAre("symbol1", "symbol2", "symbol3"));


### PR DESCRIPTION
This PR improves the way how CMake sets up `clang-tidy` in two ways: (1) It includes a `--header-filter` in order to make `clang-tidy` also check and fix header files and (2) it deactivates `clang-tidy` checks for generated code, namely by `protoc` and ANTLR.

This PR then applies more fixes found by `clang-tidy`. Curiously, some of them only show up with substrait-io#148, which consumes `abseil-cpp` differently.