### PR TITLE
style(clang-format): improve configuration and clean up includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,49 +1,16 @@
 ---
+BasedOnStyle:    llvm
+Language:        Cpp
 AccessModifierOffset: -1
 AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveAssignments: None
-AlignConsecutiveDeclarations: None
-SeparateDefinitionBlocks: Always
 AlignOperands:   false
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: Never
-AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
-BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: Never
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
-ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: false
-DisableFormat:   false
-ForEachMacros:   [ FOR_EACH, FOR_EACH_R, FOR_EACH_RANGE, ]
 IncludeCategories:
   - Regex:           '^<.*\.h(pp)?>'
     Priority:        1
@@ -52,35 +19,6 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        3
 IndentCaseLabels: true
-IndentWidth:     2
-IndentWrappedFunctionNames: false
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
+PackConstructorInitializers: NextLine
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-ReflowComments:  true
-SortIncludes: CaseSensitive
-SpaceAfterCStyleCast: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard: c++11
-TabWidth:        8
-UseTab:          Never

--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@ AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
 BreakStringLiterals: false
+IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '^<.*\.h(pp)?>'
     Priority:        1

--- a/export/planloader/planloader.cpp
+++ b/export/planloader/planloader.cpp
@@ -3,6 +3,7 @@
 #include "planloader.h"
 
 #include <substrait/common/Io.h>
+
 #include <limits>
 
 extern "C" {

--- a/export/planloader/planloader.cpp
+++ b/export/planloader/planloader.cpp
@@ -2,9 +2,9 @@
 
 #include "planloader.h"
 
-#include <substrait/common/Io.h>
-
 #include <limits>
+
+#include "substrait/common/Io.h"
 
 extern "C" {
 

--- a/export/planloader/planloader.h
+++ b/export/planloader/planloader.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <substrait/common/Io.h>
+#include "substrait/common/Io.h"
 
 extern "C" {
 

--- a/export/planloader/tests/PlanLoaderTest.cpp
+++ b/export/planloader/tests/PlanLoaderTest.cpp
@@ -4,10 +4,9 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <substrait/proto/plan.pb.h>
 
 #include <functional>
-
-#include "substrait/proto/plan.pb.h"
 
 namespace io::substrait::textplan {
 namespace {

--- a/export/planloader/tests/PlanLoaderTest.cpp
+++ b/export/planloader/tests/PlanLoaderTest.cpp
@@ -1,10 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include "../planloader.h"
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+
 #include <functional>
 
-#include "../planloader.h"
 #include "substrait/proto/plan.pb.h"
 
 namespace io::substrait::textplan {

--- a/include/substrait/common/Exceptions.h
+++ b/include/substrait/common/Exceptions.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <fmt/format.h>
+
 #include <memory>
 #include <utility>
 

--- a/include/substrait/common/Io.h
+++ b/include/substrait/common/Io.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <string_view>
+#include <absl/status/statusor.h>
+#include <substrait/proto/plan.pb.h>
 
-#include "absl/status/statusor.h"
-#include "substrait/proto/plan.pb.h"
+#include <string_view>
 
 namespace io::substrait {
 

--- a/src/substrait/common/Io.cpp
+++ b/src/substrait/common/Io.cpp
@@ -2,10 +2,11 @@
 
 #include "substrait/common/Io.h"
 
+#include <substrait/proto/plan.pb.h>
+
 #include <regex>
 #include <string_view>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/converter/LoadBinary.h"
 #include "substrait/textplan/converter/SaveBinary.h"
 #include "substrait/textplan/parser/LoadText.h"

--- a/src/substrait/common/tests/IoTest.cpp
+++ b/src/substrait/common/tests/IoTest.cpp
@@ -2,11 +2,11 @@
 
 #include "substrait/common/Io.h"
 
-#include <filesystem>
-
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <protobuf-matchers/protocol-buffer-matchers.h>
+
+#include <filesystem>
 
 #ifndef _WIN32
 #include <unistd.h>

--- a/src/substrait/common/tests/NumberUtilsTest.cpp
+++ b/src/substrait/common/tests/NumberUtilsTest.cpp
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <gtest/gtest.h>
-
 #include "substrait/common/NumberUtils.h"
+
+#include <gtest/gtest.h>
 
 using io::substrait::common::NumberUtils;
 

--- a/src/substrait/common/tests/StringUtilsTest.cpp
+++ b/src/substrait/common/tests/StringUtilsTest.cpp
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <gtest/gtest.h>
-
 #include "substrait/common/StringUtils.h"
+
+#include <gtest/gtest.h>
 
 using io::substrait::common::StringUtils;
 

--- a/src/substrait/expression/DecimalLiteral.cpp
+++ b/src/substrait/expression/DecimalLiteral.cpp
@@ -2,11 +2,11 @@
 
 #include "substrait/expression/DecimalLiteral.h"
 
-#include <sstream>
+#include <absl/numeric/int128.h>
+#include <absl/strings/numbers.h>
+#include <substrait/proto/algebra.pb.h>
 
-#include "absl/numeric/int128.h"
-#include "absl/strings/numbers.h"
-#include "substrait/proto/algebra.pb.h"
+#include <sstream>
 
 namespace io::substrait::expression {
 

--- a/src/substrait/expression/tests/DecimalTest.cpp
+++ b/src/substrait/expression/tests/DecimalTest.cpp
@@ -1,10 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include "substrait/expression/DecimalLiteral.h"
-
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include "substrait/expression/DecimalLiteral.h"
 #include "substrait/proto/algebra.pb.h"
 
 namespace io::substrait::expression {

--- a/src/substrait/expression/tests/DecimalTest.cpp
+++ b/src/substrait/expression/tests/DecimalTest.cpp
@@ -2,9 +2,9 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <substrait/proto/algebra.pb.h>
 
 #include "substrait/expression/DecimalLiteral.h"
-#include "substrait/proto/algebra.pb.h"
 
 namespace io::substrait::expression {
 

--- a/src/substrait/function/Function.cpp
+++ b/src/substrait/function/Function.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "substrait/function/Function.h"
+
 #include <sstream>
 
 namespace io::substrait {

--- a/src/substrait/function/tests/FunctionLookupTest.cpp
+++ b/src/substrait/function/tests/FunctionLookupTest.cpp
@@ -1,11 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include "substrait/function/FunctionLookup.h"
+
 #include <gtest/gtest.h>
 
 #include <filesystem>
 #include <iostream>
-
-#include "substrait/function/FunctionLookup.h"
 
 using namespace io::substrait;
 

--- a/src/substrait/proto/ProtoUtils.h
+++ b/src/substrait/proto/ProtoUtils.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <string>
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/plan.pb.h>
 
-#include "substrait/proto/algebra.pb.h"
-#include "substrait/proto/plan.pb.h"
+#include <string>
 
 namespace substrait::proto {
 

--- a/src/substrait/textplan/Any.h
+++ b/src/substrait/textplan/Any.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include <any>
+#include <fmt/format.h>
 
-#include "fmt/format.h"
+#include <any>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/PlanPrinterVisitor.cpp
+++ b/src/substrait/textplan/PlanPrinterVisitor.cpp
@@ -8,13 +8,14 @@
 #include <unistd.h>
 #endif
 
+#include <date/date.h>
+#include <substrait/proto/algebra.pb.h>
+
 #include <sstream>
 #include <string>
 
-#include "date/date.h"
 #include "substrait/expression/DecimalLiteral.h"
 #include "substrait/proto/ProtoUtils.h"
-#include "substrait/proto/algebra.pb.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
 #include "substrait/textplan/StructuredSymbolData.h"

--- a/src/substrait/textplan/PlanPrinterVisitor.h
+++ b/src/substrait/textplan/PlanPrinterVisitor.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
+#include <substrait/proto/plan.pb.h>
+
 #include <any>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTable.h"
 #include "substrait/textplan/converter/BasePlanProtoVisitor.h"

--- a/src/substrait/textplan/StructuredSymbolData.h
+++ b/src/substrait/textplan/StructuredSymbolData.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
+#include <substrait/proto/algebra.pb.h>
+
 #include <memory>
 #include <optional>
-
-#include "substrait/proto/algebra.pb.h"
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/SymbolTablePrinter.cpp
+++ b/src/substrait/textplan/SymbolTablePrinter.cpp
@@ -2,11 +2,12 @@
 
 #include "substrait/textplan/SymbolTablePrinter.h"
 
+#include <substrait/proto/algebra.pb.h>
+
 #include <set>
 #include <sstream>
 
 #include "substrait/common/Exceptions.h"
-#include "substrait/proto/algebra.pb.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/PlanPrinterVisitor.h"
 #include "substrait/textplan/StructuredSymbolData.h"

--- a/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
+++ b/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
@@ -2,13 +2,14 @@
 
 #include "substrait/textplan/converter/BasePlanProtoVisitor.h"
 
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/plan.pb.h>
+
 #include <iterator>
 #include <optional>
 #include <string>
 
 #include "substrait/common/Exceptions.h"
-#include "substrait/proto/algebra.pb.h"
-#include "substrait/proto/plan.pb.h"
 
 // The visitor should try and be tolerant of older plans.  This
 // requires calling deprecated APIs.

--- a/src/substrait/textplan/converter/BasePlanProtoVisitor.h
+++ b/src/substrait/textplan/converter/BasePlanProtoVisitor.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <any>
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/plan.pb.h>
 
-#include "substrait/proto/algebra.pb.h"
-#include "substrait/proto/plan.pb.h"
+#include <any>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/converter/InitialPlanProtoVisitor.cpp
+++ b/src/substrait/textplan/converter/InitialPlanProtoVisitor.cpp
@@ -2,13 +2,14 @@
 
 #include "substrait/textplan/converter/InitialPlanProtoVisitor.h"
 
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/plan.pb.h>
+
 #include <optional>
 #include <string>
 
 #include "substrait/common/Exceptions.h"
 #include "substrait/proto/ProtoUtils.h"
-#include "substrait/proto/algebra.pb.h"
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
 #include "substrait/textplan/Location.h"

--- a/src/substrait/textplan/converter/InitialPlanProtoVisitor.h
+++ b/src/substrait/textplan/converter/InitialPlanProtoVisitor.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
+#include <substrait/proto/plan.pb.h>
+
 #include <any>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/StructuredSymbolData.h"
 #include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTable.h"

--- a/src/substrait/textplan/converter/LoadBinary.cpp
+++ b/src/substrait/textplan/converter/LoadBinary.cpp
@@ -7,6 +7,7 @@
 #include <google/protobuf/io/tokenizer.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
+
 #include <filesystem>
 #include <fstream>
 #include <sstream>

--- a/src/substrait/textplan/converter/LoadBinary.cpp
+++ b/src/substrait/textplan/converter/LoadBinary.cpp
@@ -7,6 +7,7 @@
 #include <google/protobuf/io/tokenizer.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
+#include <substrait/proto/plan.pb.h>
 
 #include <filesystem>
 #include <fstream>
@@ -15,7 +16,6 @@
 #include <string_view>
 #include <vector>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/StringManipulation.h"
 
 namespace io::substrait::textplan {

--- a/src/substrait/textplan/converter/LoadBinary.h
+++ b/src/substrait/textplan/converter/LoadBinary.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <absl/status/statusor.h>
+
 #include <string>
 #include <string_view>
 

--- a/src/substrait/textplan/converter/ParseBinary.cpp
+++ b/src/substrait/textplan/converter/ParseBinary.cpp
@@ -2,7 +2,8 @@
 
 #include "substrait/textplan/converter/ParseBinary.h"
 
-#include "substrait/proto/plan.pb.h"
+#include <substrait/proto/plan.pb.h>
+
 #include "substrait/textplan/PlanPrinterVisitor.h"
 #include "substrait/textplan/converter/InitialPlanProtoVisitor.h"
 #include "substrait/textplan/converter/PipelineVisitor.h"

--- a/src/substrait/textplan/converter/ReferenceNormalizer.cpp
+++ b/src/substrait/textplan/converter/ReferenceNormalizer.cpp
@@ -2,10 +2,10 @@
 
 #include "substrait/textplan/converter/ReferenceNormalizer.h"
 
-#include <string>
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/plan.pb.h>
 
-#include "substrait/proto/algebra.pb.h"
-#include "substrait/proto/plan.pb.h"
+#include <string>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/converter/ReferenceNormalizer.h
+++ b/src/substrait/textplan/converter/ReferenceNormalizer.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "substrait/proto/plan.pb.h"
+#include <substrait/proto/plan.pb.h>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/converter/SaveBinary.cpp
+++ b/src/substrait/textplan/converter/SaveBinary.cpp
@@ -15,9 +15,10 @@
 #include <sys/stat.h>
 #endif
 
+#include <substrait/proto/plan.pb.h>
+
 #include <fstream>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/StringManipulation.h"
 #include "substrait/textplan/SymbolTablePrinter.h"
 #include "substrait/textplan/converter/ParseBinary.h"

--- a/src/substrait/textplan/converter/SaveBinary.h
+++ b/src/substrait/textplan/converter/SaveBinary.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "absl/status/status.h"
+#include <absl/status/status.h>
 
 namespace substrait::proto {
 class Plan;

--- a/src/substrait/textplan/parser/LoadText.cpp
+++ b/src/substrait/textplan/parser/LoadText.cpp
@@ -3,8 +3,8 @@
 #include "substrait/textplan/parser/LoadText.h"
 
 #include <absl/strings/str_join.h>
+#include <substrait/proto/plan.pb.h>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/StringManipulation.h"
 #include "substrait/textplan/SymbolTablePrinter.h"
 #include "substrait/textplan/parser/ParseText.h"

--- a/src/substrait/textplan/parser/ParseText.cpp
+++ b/src/substrait/textplan/parser/ParseText.cpp
@@ -4,6 +4,7 @@
 
 #include <ANTLRErrorStrategy.h>
 #include <antlr4-runtime.h>
+
 #include <fstream>
 #include <memory>
 #include <sstream>

--- a/src/substrait/textplan/parser/SubstraitParserErrorListener.cpp
+++ b/src/substrait/textplan/parser/SubstraitParserErrorListener.cpp
@@ -3,6 +3,7 @@
 #include "substrait/textplan/parser/SubstraitParserErrorListener.h"
 
 #include <antlr4-runtime.h>
+
 #include <string>
 
 namespace io::substrait::textplan {

--- a/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
@@ -2,6 +2,13 @@
 
 #include "substrait/textplan/parser/SubstraitPlanRelationVisitor.h"
 
+#include <absl/strings/ascii.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/strip.h>
+#include <date/tz.h>
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/type.pb.h>
+
 #include <chrono>
 #include <limits>
 #include <memory>
@@ -10,13 +17,7 @@
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
 #include "SubstraitPlanTypeVisitor.h"
-#include "absl/strings/ascii.h"
-#include "absl/strings/numbers.h"
-#include "absl/strings/strip.h"
-#include "date/tz.h"
 #include "substrait/expression/DecimalLiteral.h"
-#include "substrait/proto/algebra.pb.h"
-#include "substrait/proto/type.pb.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
 #include "substrait/textplan/Location.h"

--- a/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
@@ -2,6 +2,13 @@
 
 #include "substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.h"
 
+#include <absl/strings/ascii.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/strip.h>
+#include <date/tz.h>
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/type.pb.h>
+
 #include <chrono>
 #include <limits>
 #include <memory>
@@ -10,13 +17,7 @@
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
 #include "SubstraitPlanTypeVisitor.h"
-#include "absl/strings/ascii.h"
-#include "absl/strings/numbers.h"
-#include "absl/strings/strip.h"
-#include "date/tz.h"
 #include "substrait/expression/DecimalLiteral.h"
-#include "substrait/proto/algebra.pb.h"
-#include "substrait/proto/type.pb.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
 #include "substrait/textplan/Location.h"

--- a/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
 #include "substrait/proto/type.pb.h"
 #include "substrait/textplan/SymbolTable.h"

--- a/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
@@ -2,11 +2,12 @@
 
 #include "SubstraitPlanTypeVisitor.h"
 
+#include <substrait/proto/type.pb.h>
+
 #include <memory>
 #include <string>
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
-#include "substrait/proto/type.pb.h"
 #include "substrait/textplan/SymbolTable.h"
 #include "substrait/type/Type.h"
 

--- a/src/substrait/textplan/parser/Tool.cpp
+++ b/src/substrait/textplan/parser/Tool.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <getopt.h>
+
 #include <sstream>
 
 #include "substrait/textplan/SymbolTablePrinter.h"

--- a/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
+++ b/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
@@ -1,13 +1,13 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <protobuf-matchers/protocol-buffer-matchers.h>
+
 #include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
-
-#include <gmock/gmock-matchers.h>
-#include <gtest/gtest.h>
-#include <protobuf-matchers/protocol-buffer-matchers.h>
 
 #include "substrait/textplan/parser/ParseText.h"
 #include "substrait/textplan/tests/ParseResultMatchers.h"

--- a/src/substrait/textplan/tests/ParseResultMatchers.cpp
+++ b/src/substrait/textplan/tests/ParseResultMatchers.cpp
@@ -4,13 +4,13 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <substrait/proto/plan.pb.h>
 
 #include <memory>
 #include <set>
 #include <string>
 #include <utility>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/ParseResult.h"
 #include "substrait/textplan/SymbolTable.h"
 #include "substrait/textplan/SymbolTablePrinter.h"

--- a/src/substrait/textplan/tests/ParseResultMatchers.h
+++ b/src/substrait/textplan/tests/ParseResultMatchers.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
 
 #include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/ParseResult.h"

--- a/src/substrait/textplan/tests/ParseResultMatchers.h
+++ b/src/substrait/textplan/tests/ParseResultMatchers.h
@@ -4,11 +4,11 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <substrait/proto/plan.pb.h>
 
 #include <string>
 #include <vector>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/ParseResult.h"
 
 // NOLINTBEGIN(readability-identifier-naming)

--- a/src/substrait/textplan/tests/RoundtripTest.cpp
+++ b/src/substrait/textplan/tests/RoundtripTest.cpp
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <absl/strings/str_join.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <protobuf-matchers/protocol-buffer-matchers.h>
 
 #include <algorithm>
 #include <filesystem>
@@ -8,10 +11,6 @@
 #include <sstream>
 #include <string>
 #include <utility>
-
-#include <gmock/gmock-matchers.h>
-#include <gtest/gtest.h>
-#include <protobuf-matchers/protocol-buffer-matchers.h>
 
 #include "substrait/textplan/SymbolTablePrinter.h"
 #include "substrait/textplan/converter/LoadBinary.h"

--- a/src/substrait/textplan/tests/SymbolTableTest.cpp
+++ b/src/substrait/textplan/tests/SymbolTableTest.cpp
@@ -1,13 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include "substrait/textplan/SymbolTable.h"
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+
 #include <functional>
 
 #include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Location.h"
-#include "substrait/textplan/SymbolTable.h"
 
 namespace io::substrait::textplan {
 namespace {

--- a/src/substrait/textplan/tests/SymbolTableTest.cpp
+++ b/src/substrait/textplan/tests/SymbolTableTest.cpp
@@ -4,10 +4,10 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <substrait/proto/plan.pb.h>
 
 #include <functional>
 
-#include "substrait/proto/plan.pb.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Location.h"
 

--- a/src/substrait/type/tests/TypeTest.cpp
+++ b/src/substrait/type/tests/TypeTest.cpp
@@ -1,9 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include "substrait/type/Type.h"
+
 #include <gtest/gtest.h>
 
 #include <memory>
-#include "substrait/type/Type.h"
 
 using namespace io::substrait;
 


### PR DESCRIPTION
This PR improves the configuration of `clang-format` and cleans up the includes in three steps:

The first commit simplifies `.clang-format` by importing the LLVM style, which the previous style was most similar to, and the removing all configurations in that file that just set the default values. This does not change the effective configuration of `clang-format`.

The second commit sets the `IncludeBlocks` option of `clang-format` to `Regroup`, which makes the tool regroup includes not only within blocks (i.e., several includes seperated by blank lines) but also across them. The commit also applies the new format.

The third commit fixes the include type, i.e., whether headers are included as system headers or project headers, throughout the project. It treats any third-party library as well as the generated protobuf headers as system headers, which use angle brackets (`<.>`), and only files tracked in this repository as project headers, which use double quotes (`"."`).