### PR TITLE
style(iwyu): set up include cleaner of clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -50,6 +50,7 @@ Checks: >
   bugprone-*,
   google-*,
   modernize-*,
+  misc-include-cleaner,
   performance-*,
   portability-*,
   readability-*,
@@ -108,3 +109,5 @@ CheckOptions:
   - { key: readability-implicit-bool-conversion.AllowIntegerConditions,            value: 1         }
   - { key: readability-implicit-bool-conversion.AllowPointerConditions,            value: 1         }
   - { key: readability-function-cognitive-complexity.IgnoreMacros,                 value: 1         }
+  - { key: misc-include-cleaner.IgnoreHeaders
+      value: bits/getopt_.*;getopt.h }

--- a/export/planloader/planloader.cpp
+++ b/export/planloader/planloader.cpp
@@ -2,7 +2,12 @@
 
 #include "planloader.h"
 
+#include <substrait/proto/plan.pb.h>
+
+#include <cstdint>
+#include <cstring>
 #include <limits>
+#include <string>
 
 #include "substrait/common/Io.h"
 

--- a/export/planloader/tests/PlanLoaderTest.cpp
+++ b/export/planloader/tests/PlanLoaderTest.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 #include <substrait/proto/plan.pb.h>
 
-#include <functional>
+#include "substrait/common/Io.h"
 
 namespace io::substrait::textplan {
 namespace {

--- a/src/substrait/common/Exceptions.cpp
+++ b/src/substrait/common/Exceptions.cpp
@@ -2,7 +2,10 @@
 
 #include "substrait/common/Exceptions.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
+
+#include <cstddef>
+#include <string>
 
 namespace io::substrait::common {
 

--- a/src/substrait/common/Io.cpp
+++ b/src/substrait/common/Io.cpp
@@ -2,6 +2,8 @@
 
 #include "substrait/common/Io.h"
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
 #include <substrait/proto/plan.pb.h>
 
 #include <regex>

--- a/src/substrait/common/PlanTransformerTool.cpp
+++ b/src/substrait/common/PlanTransformerTool.cpp
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
 #include <iostream>
+#include <string>
+#include <string_view>
 
 #include "substrait/common/Io.h"
 

--- a/src/substrait/common/tests/IoTest.cpp
+++ b/src/substrait/common/tests/IoTest.cpp
@@ -5,12 +5,11 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <protobuf-matchers/protocol-buffer-matchers.h>
+#include <substrait/proto/plan.pb.h>
 
 #include <filesystem>
-
-#ifndef _WIN32
-#include <unistd.h>
-#endif
+#include <string>
+#include <system_error>
 
 using ::protobuf_matchers::EqualsProto;
 using ::protobuf_matchers::Partially;

--- a/src/substrait/expression/DecimalLiteral.cpp
+++ b/src/substrait/expression/DecimalLiteral.cpp
@@ -6,7 +6,11 @@
 #include <absl/strings/numbers.h>
 #include <substrait/proto/algebra.pb.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <sstream>
+#include <string>
 
 namespace io::substrait::expression {
 

--- a/src/substrait/expression/tests/DecimalTest.cpp
+++ b/src/substrait/expression/tests/DecimalTest.cpp
@@ -4,6 +4,11 @@
 #include <gtest/gtest.h>
 #include <substrait/proto/algebra.pb.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "substrait/expression/DecimalLiteral.h"
 
 namespace io::substrait::expression {

--- a/src/substrait/function/Extension.cpp
+++ b/src/substrait/function/Extension.cpp
@@ -4,6 +4,16 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "substrait/function/Function.h"
+#include "substrait/type/Type.h"
+
 bool decodeFunctionImpl(
     const YAML::Node& node,
     io::substrait::FunctionImplementation& function) {

--- a/src/substrait/function/Function.cpp
+++ b/src/substrait/function/Function.cpp
@@ -2,7 +2,12 @@
 
 #include "substrait/function/Function.h"
 
+#include <memory>
 #include <sstream>
+#include <string>
+#include <vector>
+
+#include "substrait/function/FunctionSignature.h"
 
 namespace io::substrait {
 

--- a/src/substrait/function/FunctionLookup.cpp
+++ b/src/substrait/function/FunctionLookup.cpp
@@ -2,6 +2,9 @@
 
 #include "substrait/function/FunctionLookup.h"
 
+#include "substrait/function/Function.h"
+#include "substrait/function/FunctionSignature.h"
+
 namespace io::substrait {
 
 FunctionImplementationPtr FunctionLookup::lookupFunction(

--- a/src/substrait/function/tests/FunctionLookupTest.cpp
+++ b/src/substrait/function/tests/FunctionLookupTest.cpp
@@ -5,7 +5,12 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
-#include <iostream>
+#include <memory>
+#include <string>
+
+#include "substrait/function/Extension.h"
+#include "substrait/function/FunctionSignature.h"
+#include "substrait/type/Type.h"
 
 using namespace io::substrait;
 

--- a/src/substrait/textplan/Location.cpp
+++ b/src/substrait/textplan/Location.cpp
@@ -2,7 +2,9 @@
 
 #include "substrait/textplan/Location.h"
 
+#include <cstddef>
 #include <functional>
+#include <variant>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/ParseResult.cpp
+++ b/src/substrait/textplan/ParseResult.cpp
@@ -2,7 +2,8 @@
 
 #include "substrait/textplan/ParseResult.h"
 
-#include <sstream>
+#include <ostream>
+#include <string>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/PlanPrinterVisitor.cpp
+++ b/src/substrait/textplan/PlanPrinterVisitor.cpp
@@ -2,10 +2,18 @@
 
 #include "substrait/textplan/PlanPrinterVisitor.h"
 
+#include <substrait/proto/type.pb.h>
+
+#include <any>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include "substrait/textplan/Location.h"
+#include "substrait/textplan/converter/BasePlanProtoVisitor.h"
+
 #ifdef _WIN32
 #include <io.h>
-#else
-#include <unistd.h>
 #endif
 
 #include <date/date.h>

--- a/src/substrait/textplan/StringManipulation.cpp
+++ b/src/substrait/textplan/StringManipulation.cpp
@@ -2,10 +2,7 @@
 
 #include "StringManipulation.h"
 
-#include <numeric>
-#include <string>
 #include <string_view>
-#include <vector>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/SubstraitErrorListener.cpp
+++ b/src/substrait/textplan/SubstraitErrorListener.cpp
@@ -2,6 +2,7 @@
 
 #include "SubstraitErrorListener.h"
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/substrait/textplan/SymbolTable.cpp
+++ b/src/substrait/textplan/SymbolTable.cpp
@@ -3,10 +3,18 @@
 
 #include <algorithm>
 #include <any>
+#include <cstddef>
+#include <cstdint>
 #include <iomanip>
+#include <ios>
 #include <map>
+#include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "substrait/common/Exceptions.h"
 #include "substrait/textplan/Any.h"

--- a/src/substrait/textplan/SymbolTablePrinter.cpp
+++ b/src/substrait/textplan/SymbolTablePrinter.cpp
@@ -3,14 +3,24 @@
 #include "substrait/textplan/SymbolTablePrinter.h"
 
 #include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/type.pb.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
 #include <set>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "substrait/common/Exceptions.h"
 #include "substrait/textplan/Any.h"
+#include "substrait/textplan/Location.h"
 #include "substrait/textplan/PlanPrinterVisitor.h"
 #include "substrait/textplan/StructuredSymbolData.h"
+#include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTable.h"
 
 namespace io::substrait::textplan {

--- a/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
+++ b/src/substrait/textplan/converter/BasePlanProtoVisitor.cpp
@@ -3,9 +3,11 @@
 #include "substrait/textplan/converter/BasePlanProtoVisitor.h"
 
 #include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/extensions/extensions.pb.h>
 #include <substrait/proto/plan.pb.h>
+#include <substrait/proto/type.pb.h>
 
-#include <iterator>
+#include <any>
 #include <optional>
 #include <string>
 

--- a/src/substrait/textplan/converter/InitialPlanProtoVisitor.cpp
+++ b/src/substrait/textplan/converter/InitialPlanProtoVisitor.cpp
@@ -3,10 +3,17 @@
 #include "substrait/textplan/converter/InitialPlanProtoVisitor.h"
 
 #include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/extensions/extensions.pb.h>
 #include <substrait/proto/plan.pb.h>
+#include <substrait/proto/type.pb.h>
 
+#include <any>
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "substrait/common/Exceptions.h"
 #include "substrait/proto/ProtoUtils.h"
@@ -15,6 +22,7 @@
 #include "substrait/textplan/Location.h"
 #include "substrait/textplan/StructuredSymbolData.h"
 #include "substrait/textplan/SymbolTable.h"
+#include "substrait/textplan/converter/BasePlanProtoVisitor.h"
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/converter/LoadBinary.cpp
+++ b/src/substrait/textplan/converter/LoadBinary.cpp
@@ -2,21 +2,25 @@
 
 #include "substrait/textplan/converter/LoadBinary.h"
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
 #include <absl/strings/str_join.h>
-#include <fmt/format.h>
+#include <absl/strings/string_view.h>
 #include <google/protobuf/io/tokenizer.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
 #include <substrait/proto/plan.pb.h>
 
+#include <cerrno>
 #include <filesystem>
 #include <fstream>
+#include <ios>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
-#include "substrait/textplan/StringManipulation.h"
+#include "fmt/core.h"
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/converter/ParseBinary.cpp
+++ b/src/substrait/textplan/converter/ParseBinary.cpp
@@ -4,6 +4,10 @@
 
 #include <substrait/proto/plan.pb.h>
 
+#include <string>
+#include <vector>
+
+#include "substrait/textplan/ParseResult.h"
 #include "substrait/textplan/PlanPrinterVisitor.h"
 #include "substrait/textplan/converter/InitialPlanProtoVisitor.h"
 #include "substrait/textplan/converter/PipelineVisitor.h"

--- a/src/substrait/textplan/converter/PipelineVisitor.cpp
+++ b/src/substrait/textplan/converter/PipelineVisitor.cpp
@@ -2,10 +2,18 @@
 
 #include "substrait/textplan/converter/PipelineVisitor.h"
 
+#include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/plan.pb.h>
+
+#include <any>
+#include <memory>
+
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
+#include "substrait/textplan/Location.h"
 #include "substrait/textplan/StructuredSymbolData.h"
 #include "substrait/textplan/SymbolTable.h"
+#include "substrait/textplan/converter/BasePlanProtoVisitor.h"
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/converter/ReferenceNormalizer.cpp
+++ b/src/substrait/textplan/converter/ReferenceNormalizer.cpp
@@ -3,9 +3,13 @@
 #include "substrait/textplan/converter/ReferenceNormalizer.h"
 
 #include <substrait/proto/algebra.pb.h>
+#include <substrait/proto/extensions/extensions.pb.h>
 #include <substrait/proto/plan.pb.h>
 
-#include <string>
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string_view>
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/converter/SaveBinary.cpp
+++ b/src/substrait/textplan/converter/SaveBinary.cpp
@@ -2,16 +2,24 @@
 
 #include "substrait/textplan/converter/SaveBinary.h"
 
+#include <absl/status/status.h>
 #include <absl/strings/str_join.h>
-#include <fmt/format.h>
+#include <fcntl.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
 
+#include <cerrno>
+#include <ios>
+#include <string>
+#include <string_view>
+
+#include "fmt/core.h"
+#include "substrait/textplan/SubstraitErrorListener.h"
+
 #ifdef _WIN32
 #include <io.h>
 #else
-#include <sys/fcntl.h>
 #include <sys/stat.h>
 #endif
 
@@ -19,7 +27,6 @@
 
 #include <fstream>
 
-#include "substrait/textplan/StringManipulation.h"
 #include "substrait/textplan/SymbolTablePrinter.h"
 #include "substrait/textplan/converter/ParseBinary.h"
 

--- a/src/substrait/textplan/converter/Tool.cpp
+++ b/src/substrait/textplan/converter/Tool.cpp
@@ -1,14 +1,17 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#include "substrait/textplan/SubstraitErrorListener.h"
 #ifndef _WIN32
 #include <glob.h>
 #endif
 
-#include <sstream>
-
 #include "substrait/common/Io.h"
 #include "substrait/textplan/SymbolTablePrinter.h"
-#include "substrait/textplan/converter/LoadBinary.h"
 #include "substrait/textplan/converter/ParseBinary.h"
 
 namespace io::substrait::textplan {

--- a/src/substrait/textplan/converter/tests/BinaryToTextPlanConversionTest.cpp
+++ b/src/substrait/textplan/converter/tests/BinaryToTextPlanConversionTest.cpp
@@ -4,6 +4,12 @@
 #include <gtest/gtest.h>
 #include <protobuf-matchers/protocol-buffer-matchers.h>
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "substrait/textplan/ParseResult.h"
+#include "substrait/textplan/SymbolTable.h"
 #include "substrait/textplan/converter/LoadBinary.h"
 #include "substrait/textplan/converter/ParseBinary.h"
 #include "substrait/textplan/tests/ParseResultMatchers.h"

--- a/src/substrait/textplan/parser/LoadText.cpp
+++ b/src/substrait/textplan/parser/LoadText.cpp
@@ -2,10 +2,13 @@
 
 #include "substrait/textplan/parser/LoadText.h"
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
 #include <absl/strings/str_join.h>
 #include <substrait/proto/plan.pb.h>
 
-#include "substrait/textplan/StringManipulation.h"
+#include <string>
+
 #include "substrait/textplan/SymbolTablePrinter.h"
 #include "substrait/textplan/parser/ParseText.h"
 

--- a/src/substrait/textplan/parser/ParseText.cpp
+++ b/src/substrait/textplan/parser/ParseText.cpp
@@ -2,16 +2,21 @@
 
 #include "substrait/textplan/parser/ParseText.h"
 
-#include <ANTLRErrorStrategy.h>
-#include <antlr4-runtime.h>
+#include <CommonTokenStream.h>
 
+#include <exception>
 #include <fstream>
+#include <iostream>
 #include <memory>
-#include <sstream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
 #include "SubstraitPlanLexer/SubstraitPlanLexer.h"
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
-#include "substrait/textplan/StructuredSymbolData.h"
+#include "substrait/textplan/ParseResult.h"
+#include "substrait/textplan/SymbolTable.h"
 #include "substrait/textplan/parser/SubstraitParserErrorListener.h"
 #include "substrait/textplan/parser/SubstraitPlanPipelineVisitor.h"
 #include "substrait/textplan/parser/SubstraitPlanRelationVisitor.h"

--- a/src/substrait/textplan/parser/SubstraitParserErrorListener.cpp
+++ b/src/substrait/textplan/parser/SubstraitParserErrorListener.cpp
@@ -2,9 +2,14 @@
 
 #include "substrait/textplan/parser/SubstraitParserErrorListener.h"
 
-#include <antlr4-runtime.h>
+#include <Recognizer.h>
+#include <Token.h>
 
+#include <cstddef>
+#include <exception>
 #include <string>
+
+#include "substrait/textplan/SubstraitErrorListener.h"
 
 namespace io::substrait::textplan {
 

--- a/src/substrait/textplan/parser/SubstraitPlanPipelineVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanPipelineVisitor.cpp
@@ -2,9 +2,12 @@
 
 #include "substrait/textplan/parser/SubstraitPlanPipelineVisitor.h"
 
+#include <any>
 #include <memory>
+#include <string>
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
+#include "SubstraitPlanParser/SubstraitPlanParserBaseVisitor.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
 #include "substrait/textplan/Location.h"

--- a/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanRelationVisitor.cpp
@@ -2,27 +2,40 @@
 
 #include "substrait/textplan/parser/SubstraitPlanRelationVisitor.h"
 
+#include <Token.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/strip.h>
 #include <date/tz.h>
 #include <substrait/proto/algebra.pb.h>
 #include <substrait/proto/type.pb.h>
+#include <tree/TerminalNode.h>
 
+#include <algorithm>
+#include <any>
+#include <cctype>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
 #include "SubstraitPlanTypeVisitor.h"
+#include "date/date.h"
 #include "substrait/expression/DecimalLiteral.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
 #include "substrait/textplan/Location.h"
 #include "substrait/textplan/StringManipulation.h"
 #include "substrait/textplan/StructuredSymbolData.h"
+#include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTable.h"
 
 namespace io::substrait::textplan {

--- a/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.cpp
@@ -2,27 +2,41 @@
 
 #include "substrait/textplan/parser/SubstraitPlanSubqueryRelationVisitor.h"
 
+#include <Token.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/strip.h>
 #include <date/tz.h>
 #include <substrait/proto/algebra.pb.h>
 #include <substrait/proto/type.pb.h>
+#include <tree/TerminalNode.h>
 
+#include <algorithm>
+#include <any>
+#include <cctype>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
 #include "SubstraitPlanTypeVisitor.h"
+#include "date/date.h"
 #include "substrait/expression/DecimalLiteral.h"
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Finally.h"
 #include "substrait/textplan/Location.h"
 #include "substrait/textplan/StringManipulation.h"
 #include "substrait/textplan/StructuredSymbolData.h"
+#include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTable.h"
 
 namespace io::substrait::textplan {

--- a/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanTypeVisitor.cpp
@@ -2,13 +2,16 @@
 
 #include "SubstraitPlanTypeVisitor.h"
 
+#include <ParserRuleContext.h>
+#include <RuleContext.h>
 #include <substrait/proto/type.pb.h>
 
+#include <any>
+#include <cstdint>
 #include <memory>
 #include <string>
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
-#include "substrait/textplan/SymbolTable.h"
 #include "substrait/type/Type.h"
 
 namespace io::substrait::textplan {

--- a/src/substrait/textplan/parser/SubstraitPlanVisitor.cpp
+++ b/src/substrait/textplan/parser/SubstraitPlanVisitor.cpp
@@ -2,7 +2,17 @@
 
 #include "substrait/textplan/parser/SubstraitPlanVisitor.h"
 
+#include <substrait/proto/algebra.pb.h>
+
+#include <algorithm>
+#include <any>
+#include <cctype>
+#include <cstdint>
 #include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "SubstraitPlanParser/SubstraitPlanParser.h"
 #include "substrait/textplan/Any.h"

--- a/src/substrait/textplan/parser/Tool.cpp
+++ b/src/substrait/textplan/parser/Tool.cpp
@@ -2,8 +2,12 @@
 
 #include <getopt.h>
 
-#include <sstream>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <string>
 
+#include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTablePrinter.h"
 #include "substrait/textplan/parser/ParseText.h"
 

--- a/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
+++ b/src/substrait/textplan/parser/tests/TextPlanParserTest.cpp
@@ -3,12 +3,14 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <protobuf-matchers/protocol-buffer-matchers.h>
+#include <substrait/proto/plan.pb.h>
 
 #include <algorithm>
-#include <memory>
 #include <string>
-#include <utility>
+#include <vector>
 
+#include "substrait/textplan/ParseResult.h"
+#include "substrait/textplan/SymbolTable.h"
 #include "substrait/textplan/parser/ParseText.h"
 #include "substrait/textplan/tests/ParseResultMatchers.h"
 

--- a/src/substrait/textplan/tests/ParseResultMatchers.cpp
+++ b/src/substrait/textplan/tests/ParseResultMatchers.cpp
@@ -6,12 +6,18 @@
 #include <gtest/gtest.h>
 #include <substrait/proto/plan.pb.h>
 
+#include <algorithm>
+#include <cctype>
+#include <iterator>
 #include <memory>
+#include <ostream>
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "substrait/textplan/ParseResult.h"
+#include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTable.h"
 #include "substrait/textplan/SymbolTablePrinter.h"
 

--- a/src/substrait/textplan/tests/RoundtripTest.cpp
+++ b/src/substrait/textplan/tests/RoundtripTest.cpp
@@ -1,17 +1,17 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <absl/strings/str_join.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <protobuf-matchers/protocol-buffer-matchers.h>
 
 #include <algorithm>
 #include <filesystem>
-#include <memory>
+#include <iomanip>
 #include <sstream>
 #include <string>
-#include <utility>
+#include <vector>
 
+#include "substrait/textplan/SubstraitErrorListener.h"
 #include "substrait/textplan/SymbolTablePrinter.h"
 #include "substrait/textplan/converter/LoadBinary.h"
 #include "substrait/textplan/converter/ParseBinary.h"

--- a/src/substrait/textplan/tests/SymbolTableTest.cpp
+++ b/src/substrait/textplan/tests/SymbolTableTest.cpp
@@ -4,9 +4,12 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <substrait/proto/extensions/extensions.pb.h>
 #include <substrait/proto/plan.pb.h>
 
-#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "substrait/textplan/Any.h"
 #include "substrait/textplan/Location.h"

--- a/src/substrait/type/Type.cpp
+++ b/src/substrait/type/Type.cpp
@@ -3,8 +3,13 @@
 #include "substrait/type/Type.h"
 
 #include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <memory>
 #include <sstream>
-#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "substrait/common/Exceptions.h"
 #include "substrait/common/NumberUtils.h"

--- a/src/substrait/type/tests/TypeTest.cpp
+++ b/src/substrait/type/tests/TypeTest.cpp
@@ -4,7 +4,9 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <memory>
+#include <string>
 
 using namespace io::substrait;
 


### PR DESCRIPTION
This PR is stacked on #152.

This PR enables the `misc-include-cleaner` of `clang-tidy`, which enforces a version of include-what-you-use (IWYU), and applies all suggested fixes.

This has been *a lot* easier to set up than "proper" IWYU (#151) but arguably achieves the same goal and could, thus, be seen as addressing  #70.